### PR TITLE
Lost realm is no longer calculated to war fatigue

### DIFF
--- a/src/main/java/org/openRealmOfStars/game/States/AITurnView.java
+++ b/src/main/java/org/openRealmOfStars/game/States/AITurnView.java
@@ -1306,10 +1306,13 @@ public class AITurnView extends BlackPanel {
         }
       }
     }
+    int[] numberOfPlanets = new int[game.getStarMap().getPlayerList()
+                                    .getCurrentMaxRealms()];
     for (int i = 0; i < game.getStarMap().getPlanetList().size(); i++) {
       Planet planet = game.getStarMap().getPlanetList().get(i);
       if (planet.getPlanetPlayerInfo() != null) {
         PlayerInfo info = planet.getPlanetPlayerInfo();
+        numberOfPlanets[planet.getPlanetOwnerIndex()]++;
         boolean enemyOrbiting = false;
         Fleet fleetOrbiting = game.getStarMap().getFleetByCoordinate(
             planet.getX(), planet.getY());
@@ -1330,6 +1333,27 @@ public class AITurnView extends BlackPanel {
         }
         // Fleets and planets do the scan
         game.getStarMap().doFleetScanUpdate(info, null, planet);
+      }
+    }
+    for (int i = 0; i < numberOfPlanets.length; i++) {
+      if (numberOfPlanets[i] == 0) {
+        boolean lost = false;
+        for (int j = 0;
+            j < game.getStarMap().getPlayerList().getCurrentMaxRealms(); j++) {
+          PlayerInfo info = game.getStarMap().getPlayerList()
+              .getPlayerInfoByIndex(j);
+          DiplomacyBonusList list = info.getDiplomacy().getDiplomacyList(i);
+          if (list != null) {
+            lost = list.addBonus(DiplomacyBonusType.REALM_LOST,
+                info.getRace());
+            if (lost) {
+              PlayerInfo realm = game.getStarMap().getPlayerList()
+                  .getPlayerInfoByIndex(i);
+              NewsData news = NewsFactory.makeLostNews(realm);
+              game.getStarMap().getNewsCorpData().addNews(news);
+            }
+          }
+        }
       }
     }
     game.getStarMap().updateEspionage();

--- a/src/main/java/org/openRealmOfStars/player/diplomacy/Diplomacy.java
+++ b/src/main/java/org/openRealmOfStars/player/diplomacy/Diplomacy.java
@@ -200,6 +200,21 @@ public class Diplomacy {
   }
 
   /**
+   * Is certain player(index) with player who is asking lost?
+   * @param index Player index
+   * @return True if realm has lost
+   */
+  public boolean isLost(final int index) {
+    if (index > -1 && index < diplomacyList.length
+        && diplomacyList[index] != null
+        && !diplomacyList[index].isBonusType(
+            DiplomacyBonusType.BOARD_PLAYER)) {
+      return diplomacyList[index].isBonusType(DiplomacyBonusType.REALM_LOST);
+    }
+    return false;
+  }
+
+  /**
    * Is certain player(index) with player who is asking in peace?
    * @param index Player index
    * @return True if peace is between two players
@@ -531,7 +546,7 @@ public class Diplomacy {
   public int getNumberOfWar() {
     int result = 0;
     for (int i = 0; i < diplomacyList.length; i++) {
-      if (isWar(i)) {
+      if (isWar(i) && !isLost(i)) {
         result++;
       }
     }

--- a/src/main/java/org/openRealmOfStars/player/diplomacy/DiplomacyBonus.java
+++ b/src/main/java/org/openRealmOfStars/player/diplomacy/DiplomacyBonus.java
@@ -314,6 +314,12 @@ public class DiplomacyBonus {
        }
        break;
      }
+     case REALM_LOST: {
+       onlyOne = true;
+       bonusValue = 0;
+       bonusLasting = 255;
+       break;
+     }
      default: {
        throw new IllegalArgumentException("Unknown bonus type!!");
      }

--- a/src/main/java/org/openRealmOfStars/player/diplomacy/DiplomacyBonusType.java
+++ b/src/main/java/org/openRealmOfStars/player/diplomacy/DiplomacyBonusType.java
@@ -118,13 +118,22 @@ public enum DiplomacyBonusType {
    * Bonus for realm which did not like the made embargo.
    * So this is negative bonus.
    */
-  DISLIKED_EMBARGO;
+  DISLIKED_EMBARGO,
+  /**
+   * Realm has lost the game which means that
+   * all it's planets have been conquered.
+   * In theory realm still could have ships left and in theory
+   * could colonize new planets, but changes are slim.
+   * Most important purpose of this is that other realms
+   * do not get war bonus or fatigue against this realm anymore.
+   */
+  REALM_LOST;
 
 
   /**
    * Number of Bonus type. This should be one larger than actual bonus types.
    */
-  public static final int MAX_BONUS_TYPE = 23;
+  public static final int MAX_BONUS_TYPE = 24;
 
   /**
    * Get ShipHullType index
@@ -155,6 +164,7 @@ public enum DiplomacyBonusType {
       case EMBARGO: return 20;
       case LIKED_EMBARGO: return 21;
       case DISLIKED_EMBARGO: return 22;
+      case REALM_LOST: return 23;
       default: throw new IllegalArgumentException("No such Diplomacy Bonus"
           + " Type!");
     }
@@ -213,6 +223,8 @@ public enum DiplomacyBonusType {
       return DiplomacyBonusType.LIKED_EMBARGO;
     case 22:
       return DiplomacyBonusType.DISLIKED_EMBARGO;
+    case 23:
+      return DiplomacyBonusType.REALM_LOST;
     default:
       throw new IllegalArgumentException("Unexpected diplomacy bonus type!");
     }

--- a/src/main/java/org/openRealmOfStars/starMap/newsCorp/NewsFactory.java
+++ b/src/main/java/org/openRealmOfStars/starMap/newsCorp/NewsFactory.java
@@ -242,6 +242,39 @@ public final class NewsFactory {
   }
 
   /**
+   * Make realm lost news. Realm lost it's final planet
+   * @param realm PlayerInfo who lost
+   * @return NewsData
+   */
+  public static NewsData makeLostNews(final PlayerInfo realm) {
+    NewsData news = new NewsData();
+    ImageInstruction instructions = new ImageInstruction();
+    instructions.addBackground(ImageInstruction.BACKGROUND_BLACK);
+    instructions.addImage(realm.getRace().getNameSingle());
+    switch (DiceGenerator.getRandom(2)) {
+      case 0:
+      default: {
+        instructions.addText("REALM LOST!");
+        break;
+      }
+      case 1: {
+        instructions.addText("EXTERMINATION!");
+        break;
+      }
+      case 2: {
+        instructions.addText("ANHILATION!");
+        break;
+      }
+    }
+    news.setImageInstructions(instructions.build());
+    StringBuilder sb = new StringBuilder(100);
+    sb.append(realm.getEmpireName());
+    sb.append(" has lost its last planet from the known galaxy! ");
+    sb.append("Galaxy now has one realm less...");
+    news.setNewsText(sb.toString());
+    return news;
+  }
+  /**
    * Make Trade fleet news. Trader's ship arrives to another planet
    * @param trader PlayerInfo who is trading
    * @param planet Where to trader

--- a/src/test/java/org/openRealmOfStars/player/diplomacy/DiplomacyBonusTest.java
+++ b/src/test/java/org/openRealmOfStars/player/diplomacy/DiplomacyBonusTest.java
@@ -57,9 +57,9 @@ public class DiplomacyBonusTest {
   public void testHuman() {
     //                 IN_WAR,WDEC,INTA,IN_A,DICA,BOCR,GVAL,DEMA,DTR,SRAC,LONG_PEACE 
     int[] bonusValues =  {-30,  -8,  12,  25,  -5,  -2,   3,  -5,  5,   5,  5, -3, -6, 0, 30, -4,
-        10, 2, 4, 0, -5, 4, -4};
+        10, 2, 4, 0, -5, 4, -4, 0};
     int[] bonusLasting = {255, 255, 255, 255, 200,  20,  50, 80, 110, 255, 1, 70, 120, 10, 255, 30,
-        20, 255, 255, 255, 20, 60, 60};
+        20, 255, 255, 255, 20, 60, 60, 255};
     for (int i = 0; i < DiplomacyBonusType.MAX_BONUS_TYPE; i++) {
       DiplomacyBonus bonus = new DiplomacyBonus(
           DiplomacyBonusType.getTypeByIndex(i), SpaceRace.HUMAN);
@@ -80,11 +80,11 @@ public class DiplomacyBonusTest {
   public void testCentaurs() {
     //                 IN_WAR,WDEC,INTA,IN_A,DICA,BOCR,GVAL,DEMA,DTR,SRAC,LONG_PEACE 
     int[] bonusValues =  {-30,  -8,  12,  25,  -8,  -2,   2,  -5,  4,   5,  5, -3, -8, 0, 25, -4,
-        10, -1, 3, 0, -5, 4, -4};
+        10, -1, 3, 0, -5, 4, -4, 0};
     int[] bonusLasting = {255, 255, 255, 255, 200,  20,  50, 80, 100, 255, 1, 70, 120, 10, 255, 30,
-        20, 255, 255, 255, 20, 60, 60};
+        20, 255, 255, 255, 20, 60, 60, 255};
     int[] bonusLasting2 = {255, 255, 255, 255, 199,  19,  49, 79, 99, 255, 2, 69, 119, 9, 255, 29,
-        19, 255, 255, 255, 19, 59, 59};
+        19, 255, 255, 255, 19, 59, 59, 255};
     for (int i = 0; i < DiplomacyBonusType.MAX_BONUS_TYPE; i++) {
       DiplomacyBonus bonus = new DiplomacyBonus(
           DiplomacyBonusType.getTypeByIndex(i), SpaceRace.CENTAURS);
@@ -100,9 +100,9 @@ public class DiplomacyBonusTest {
   public void testGreyans() {
     //                 IN_WAR,WDEC,INTA,IN_A,DICA,BOCR,GVAL,DEMA,DTR,SRAC,LONG_PEACE 
     int[] bonusValues =  {-40,  -8,  18,  30,  -5,  -2,   2,  -5,  4,   5,  5, -3, -5, 0, 25, -4,
-        10, 0, 3, 0, -5, 4, -4};
+        10, 0, 3, 0, -5, 4, -4, 0};
     int[] bonusLasting = {255, 255, 255, 255, 200,  20,  50, 80, 100, 255, 1, 70, 100, 10, 255, 30,
-        20, 255, 255, 255, 20, 60, 60};
+        20, 255, 255, 255, 20, 60, 60, 255};
     for (int i = 0; i < DiplomacyBonusType.MAX_BONUS_TYPE; i++) {
       DiplomacyBonus bonus = new DiplomacyBonus(
           DiplomacyBonusType.getTypeByIndex(i), SpaceRace.GREYANS);
@@ -116,9 +116,9 @@ public class DiplomacyBonusTest {
   public void testSporks() {
     //                 IN_WAR,WDEC,INTA,IN_A,DICA,BOCR,GVAL,DEMA,DTR,SRAC,LONG_PEACE 
     int[] bonusValues =  {-30,  -2,  12,  25,  -3,  -1,   2,  -10,  4,   2,  1, -2, -4, 0, 20, -2,
-        13, -3, 3, 0, -8, 2, -2};
+        13, -3, 3, 0, -8, 2, -2, 0};
     int[] bonusLasting = {255, 255, 255, 255, 200,  10,  50, 150, 100, 255, 1, 60, 100, 10, 255, 20,
-        20, 255, 255, 255, 20, 60, 60};
+        20, 255, 255, 255, 20, 60, 60, 255};
     for (int i = 0; i < DiplomacyBonusType.MAX_BONUS_TYPE; i++) {
       DiplomacyBonus bonus = new DiplomacyBonus(
           DiplomacyBonusType.getTypeByIndex(i), SpaceRace.SPORKS);
@@ -132,9 +132,9 @@ public class DiplomacyBonusTest {
   public void testMechions() {
     //                 IN_WAR,WDEC,INTA,IN_A,DICA,BOCR,GVAL,DEMA,DTR,SRAC,LONG_PEACE 
     int[] bonusValues =  {-30,  -8,  12,  25,  -5,  -3,   2,  -5,  4,  -3,  5, -1, -3, 0, 25, -6,
-        8, -2, 3, 0, -5, 2, -2};
+        8, -2, 3, 0, -5, 2, -2, 0};
     int[] bonusLasting = {255, 255, 255, 255, 200,  10,  50, 80, 100, 255, 1, 20, 80, 10, 255, 20,
-        20, 255, 255, 255, 20, 60, 60};
+        20, 255, 255, 255, 20, 60, 60, 255};
     for (int i = 0; i < DiplomacyBonusType.MAX_BONUS_TYPE; i++) {
       DiplomacyBonus bonus = new DiplomacyBonus(
           DiplomacyBonusType.getTypeByIndex(i), SpaceRace.MECHIONS);
@@ -149,9 +149,9 @@ public class DiplomacyBonusTest {
   public void testMothoids() {
     //                 IN_WAR,WDEC,INTA,IN_A,DICA,BOCR,GVAL,DEMA,DTR,SRAC,LONG_PEACE 
     int[] bonusValues =  {-30,  -8,  12,  25,  -5,  -2,   2,  -5,  4,   5,  8, -3, -5, 0, 25, -4,
-        10, 0, 3, 0, -5, 2, -2};
+        10, 0, 3, 0, -5, 2, -2, 0};
     int[] bonusLasting = {255, 255, 255, 255, 200,  20,  50, 80, 100, 255, 1, 70, 100, 10, 255, 30,
-        20, 255, 255, 255, 20, 60, 60};
+        20, 255, 255, 255, 20, 60, 60, 255};
     for (int i = 0; i < DiplomacyBonusType.MAX_BONUS_TYPE; i++) {
       DiplomacyBonus bonus = new DiplomacyBonus(
           DiplomacyBonusType.getTypeByIndex(i), SpaceRace.MOTHOIDS);
@@ -165,9 +165,9 @@ public class DiplomacyBonusTest {
   public void testTeuthidaes() {
     //                 IN_WAR,WDEC,INTA,IN_A,DICA,BOCR,GVAL,DEMA,DTR,SRAC,LONG_PEACE 
     int[] bonusValues =  {-30,  -8,  12,  25,  -5,  -2,   2,  -5,  4,   -3,  5, -3, -6, 0, 20, -2,
-        15, -2, 3, 0, -5, 2, -2};
+        15, -2, 3, 0, -5, 2, -2, 0};
     int[] bonusLasting = {255, 255, 255, 255, 200,  20,  50, 80, 100, 255, 1, 70, 120, 10, 255, 20,
-        20, 255, 255, 255, 20, 60, 60};
+        20, 255, 255, 255, 20, 60, 60, 255};
     for (int i = 0; i < DiplomacyBonusType.MAX_BONUS_TYPE; i++) {
       DiplomacyBonus bonus = new DiplomacyBonus(
           DiplomacyBonusType.getTypeByIndex(i), SpaceRace.TEUTHIDAES);
@@ -181,9 +181,9 @@ public class DiplomacyBonusTest {
   public void testHomarians() {
     //                 IN_WAR,WDEC,INTA,IN_A,DICA,BOCR,GVAL,DEMA,DTR,SRAC,LONG_PEACE 
     int[] bonusValues =  {-30,  -8,  12,  25,  -5,  -2,   2,  -5,  4,   5,  5, -3, -5, 0, 30, -4,
-        8, 1, 3, 0, -5, 2, -2};
+        8, 1, 3, 0, -5, 2, -2, 0};
     int[] bonusLasting = {255, 255, 255, 255, 200,  20,  50, 80, 100, 255, 1, 70, 100, 10, 255, 30,
-        20, 255, 255, 255, 20, 60, 60};
+        20, 255, 255, 255, 20, 60, 60, 255};
     for (int i = 0; i < DiplomacyBonusType.MAX_BONUS_TYPE; i++) {
       DiplomacyBonus bonus = new DiplomacyBonus(
           DiplomacyBonusType.getTypeByIndex(i), SpaceRace.HOMARIANS);
@@ -204,9 +204,9 @@ public class DiplomacyBonusTest {
   public void testScaurians() {
     //                 IN_WAR,WDEC,INTA,IN_A,DICA,BOCR,GVAL,DEMA,DTR,SRAC,LONG_PEACE 
     int[] bonusValues =  {-30,  -8,  18,  25,  -5,  -1,   3,  -5,  5,   5,  6, -3, -4, 0, 25, -4,
-        10, 1, 6, 0, -8, 4, -4};
+        10, 1, 6, 0, -8, 4, -4, 0};
     int[] bonusLasting = {255, 255, 255, 255, 200,  10,  50, 80, 110, 255, 1, 70, 100, 10, 255, 30,
-        20, 255, 255, 255, 20, 60, 60};
+        20, 255, 255, 255, 20, 60, 60, 255};
     for (int i = 0; i < DiplomacyBonusType.MAX_BONUS_TYPE; i++) {
       DiplomacyBonus bonus = new DiplomacyBonus(
           DiplomacyBonusType.getTypeByIndex(i), SpaceRace.SCAURIANS);

--- a/src/test/java/org/openRealmOfStars/player/diplomacy/DiplomacyBonusTest.java
+++ b/src/test/java/org/openRealmOfStars/player/diplomacy/DiplomacyBonusTest.java
@@ -215,4 +215,20 @@ public class DiplomacyBonusTest {
     }
   }
 
+  @Test
+  @Category(org.openRealmOfStars.UnitTest.class)
+  public void testChiraloids() {
+    //                 IN_WAR,WDEC,INTA,IN_A,DICA,BOCR,GVAL,DEMA,DTR,SRAC,LONG_PEACE 
+    int[] bonusValues =  {-30,  -8,  12,  25,  -5,  -2,   2,  -5,  4,   5,  5, -2, 2, 0, 25, -2,
+        12, -4, 3, 0, -8, 2, -2, 0};
+    int[] bonusLasting = {255, 255, 255, 255, 200,  20,  50, 80, 100, 255, 1, 60, 40, 10, 255, 20,
+        20, 255, 255, 255, 20, 60, 60, 255};
+    for (int i = 0; i < DiplomacyBonusType.MAX_BONUS_TYPE; i++) {
+      DiplomacyBonus bonus = new DiplomacyBonus(
+          DiplomacyBonusType.getTypeByIndex(i), SpaceRace.CHIRALOIDS);
+      assertEquals(bonusValues[i], bonus.getBonusValue());
+      assertEquals(bonusLasting[i], bonus.getBonusLasting());
+    }
+  }
+
 }

--- a/src/test/java/org/openRealmOfStars/player/diplomacy/DiplomacyTest.java
+++ b/src/test/java/org/openRealmOfStars/player/diplomacy/DiplomacyTest.java
@@ -154,6 +154,20 @@ public class DiplomacyTest {
 
   @Test
   @Category(org.openRealmOfStars.UnitTest.class)
+  public void testIsLost() {
+    Diplomacy diplomacy = new Diplomacy(4, 1);
+    assertEquals(false, diplomacy.isLost(0));
+    assertEquals(0, diplomacy.getNumberOfWar());
+    diplomacy.getDiplomacyList(0).addBonus(DiplomacyBonusType.IN_WAR,
+        SpaceRace.SPORKS);
+    assertEquals(1, diplomacy.getNumberOfWar());
+    diplomacy.getDiplomacyList(0).addBonus(DiplomacyBonusType.REALM_LOST,
+        SpaceRace.SPORKS);
+    assertEquals(0, diplomacy.getNumberOfWar());
+  }
+
+  @Test
+  @Category(org.openRealmOfStars.UnitTest.class)
   public void testInTradeAlliance() {
     Diplomacy diplomacy = new Diplomacy(4, 1);
     assertEquals(Diplomacy.NEUTRAL, diplomacy.getLiking(0));

--- a/src/test/java/org/openRealmOfStars/starMap/newsCorp/NewsFactoryTest.java
+++ b/src/test/java/org/openRealmOfStars/starMap/newsCorp/NewsFactoryTest.java
@@ -549,6 +549,18 @@ public class NewsFactoryTest {
 
   @Test
   @Category(org.openRealmOfStars.UnitTest.class)
+  public void testLostNews() {
+    PlayerInfo info = Mockito.mock(PlayerInfo.class);
+    Mockito.when(info.getEmpireName()).thenReturn("Empire of Test");
+    Mockito.when(info.getRace()).thenReturn(SpaceRace.HUMAN);
+    NewsData news = NewsFactory.makeLostNews(info);
+    assertEquals(true, news.getImageInstructions().contains(
+        "Human"));
+    assertEquals(true, news.getNewsText().contains(info.getEmpireName()));
+  }
+
+  @Test
+  @Category(org.openRealmOfStars.UnitTest.class)
   public void testPirateNews() {
     PlayerInfo info = Mockito.mock(PlayerInfo.class);
     Mockito.when(info.getEmpireName()).thenReturn("Space pirates");


### PR DESCRIPTION
Realm with Lost realm diplomacy bonus is no longer calculated to war fatigue. Some point destroying other realm is the only way get the war fatigue bonus.