### PR TITLE
#289 Correct exception logging

### DIFF
--- a/src/main/java/org/openRealmOfStars/utilities/ErrorLogger.java
+++ b/src/main/java/org/openRealmOfStars/utilities/ErrorLogger.java
@@ -46,12 +46,13 @@ public final class ErrorLogger {
     if (exception.getStackTrace().length == 0) {
       //This should never happens but you never know...
       ErrorLogger.log(exception.getMessage());
+    } else {
+      StackTraceElement stackTraceElement = exception.getStackTrace()[0];
+      ErrorLogger.log(stackTraceElement.getClassName()
+              + " - "
+              + "Line " + stackTraceElement.getLineNumber()
+              + " - "
+              + exception.getMessage());
     }
-    StackTraceElement stackTraceElement = exception.getStackTrace()[0];
-    ErrorLogger.log(stackTraceElement.getClassName()
-            + " - "
-            + stackTraceElement.getLineNumber()
-            + " - "
-            +  exception.getMessage());
   }
 }

--- a/src/test/java/org/openRealmOfStars/utilities/ErrorLoggerTest.java
+++ b/src/test/java/org/openRealmOfStars/utilities/ErrorLoggerTest.java
@@ -55,7 +55,7 @@ public class ErrorLoggerTest {
         Mockito.verify(System.err, Mockito.times(1))
                 .println(stackTraceElement.getClassName()
                     + " - "
-                    + stackTraceElement.getLineNumber()
+                    + "Line " + stackTraceElement.getLineNumber()
                     + " - "
                     +  exception.getMessage());
         System.setErr(err);


### PR DESCRIPTION
This pull request corrects an error in how exception logs are created introduced by 6250dd7838de852cec2ceb513678228d460d20f5. It also improve the readability of the log message.