### PR TITLE
#294 Stops human to start diplomacy with space pirates.

### DIFF
--- a/src/main/java/org/openRealmOfStars/game/States/FleetView.java
+++ b/src/main/java/org/openRealmOfStars/game/States/FleetView.java
@@ -712,6 +712,10 @@ public class FleetView extends BlackPanel implements ListSelectionListener {
         || tile.getName().equals(TileNames.DEEP_SPACE_ANCHOR2)) {
         imgBase.setTitle("In Deep Space Anchor...");
       }
+      PlayerInfo fleetInfo = starMap.getPlayerInfoByFleet(fleet);
+      if (fleetInfo != null && fleetInfo.isBoard()) {
+        hailBtn.setEnabled(false);
+      }
     }
   }
 


### PR DESCRIPTION
This add checks if fleet playerinfo is board player then
diplomatic screen won't start.