### PR TITLE
#372 add new message when leaders is unassigned

### DIFF
--- a/src/main/java/org/openRealmOfStars/game/States/AITurnView.java
+++ b/src/main/java/org/openRealmOfStars/game/States/AITurnView.java
@@ -2095,6 +2095,13 @@ public class AITurnView extends BlackPanel {
             && leader.hasPerk(Perk.CORRUPTED)) {
           realm.setTotalCredits(realm.getTotalCredits() - 1);
         }
+        if (leader.getJob() == Job.UNASSIGNED) {
+          Message msg = new Message(MessageType.LEADER,
+                  leader.getCallName() + " is unassigned!",
+                  Icons.getIconByName(Icons.ICON_TUTORIAL));
+          msg.setMatchByString("Index:" + realm.getLeaderIndex(leader));
+          realm.getMsgList().addUpcomingMessage(msg);
+        }
       }
       if (leader.getJob() == Job.RULER) {
         int numberOfPlanet = 0;


### PR DESCRIPTION
Hi @tuomount , I added message when there is a leader which is unassigned.  Info message appears in info panel in lower right corner. Please check the improvement. 
I have idea how to do JUnits test on it, but I can't find any tests abou leaders messages or something like that. 