### PR TITLE
Update MapInfoPanel.java

### DIFF
--- a/src/main/java/org/openRealmOfStars/gui/infopanel/MapInfoPanel.java
+++ b/src/main/java/org/openRealmOfStars/gui/infopanel/MapInfoPanel.java
@@ -466,7 +466,7 @@ public class MapInfoPanel extends InfoPanel {
       }
       g2d.dispose();
       imageLabel.setImage(img);
-      setTitle("Galatic info");
+      setTitle("Galactic info");
       textArea.setText(tile.getDescription());
       this.repaint();
     } else {


### PR DESCRIPTION
Small typo on Galactic Info panel. Changed "Galatic Info" to "Galactic Info". Only occurs when clicking stars.
![image](https://user-images.githubusercontent.com/106123482/171073471-f4bb9c14-70e2-4732-a2de-e75f0812b338.png)
