### PR TITLE
Make Coordinate immutable

### DIFF
--- a/src/main/java/org/openRealmOfStars/game/States/HistoryView.java
+++ b/src/main/java/org/openRealmOfStars/game/States/HistoryView.java
@@ -366,7 +366,8 @@ public class HistoryView extends BlackPanel {
   public void handleAction(final ActionEvent arg0) {
     if (arg0.getActionCommand().equals(GameCommands.COMMAND_ANIMATION_TIMER)) {
       if (targetCoordinate != null) {
-        mapPanel.getHistoryCoordinates().moveTowards(targetCoordinate);
+        mapPanel.moveHistoryTowards(targetCoordinate.getX(),
+            targetCoordinate.getY());
       }
       mapPanel.drawHistoryMap(this.map);
       mapPanel.repaint();

--- a/src/main/java/org/openRealmOfStars/gui/mapPanel/MapPanel.java
+++ b/src/main/java/org/openRealmOfStars/gui/mapPanel/MapPanel.java
@@ -172,10 +172,14 @@ public class MapPanel extends JPanel {
    */
   private int[][] historyCultures;
 
-  /**
-   * History map coordinate
-   */
-  private Coordinate historyCoordinates;
+  /** Whether were history map coordinates initialized */
+  private boolean historyCoordInitialized = false;
+
+  /** History map coordinate X component */
+  private int historyCoordX;
+
+  /** History map coordinate Y component */
+  private int historyCoordY;
 
   /**
    * Image to be drawn on lower left side of the map in history view
@@ -317,7 +321,7 @@ public class MapPanel extends JPanel {
     int width = DEFAULT_WIDTH;
     int height = DEFAULT_HEIGHT;
     historyCultures = null;
-    historyCoordinates = null;
+    historyCoordInitialized = false;
     setShowMiniMap(false);
     tileOverride = null;
     improvedParallax = false;
@@ -1427,12 +1431,12 @@ public class MapPanel extends JPanel {
     int tileHeight = Tile.getMaxHeight(Tile.ZOOM_NORMAL);
     Graphics2D gr = screen.createGraphics();
     // Center coordinates
-    if (historyCoordinates == null) {
-      historyCoordinates = new Coordinate(starMap.getDrawX(),
-          starMap.getDrawY());
+    if (!historyCoordInitialized) {
+      historyCoordX = starMap.getDrawX();
+      historyCoordY = starMap.getDrawY();
     }
-    int cx = historyCoordinates.getX();
-    int cy = historyCoordinates.getY();
+    int cx = historyCoordX;
+    int cy = historyCoordY;
     starMap.setCursorPos(cx, cy);
     if (cx < viewPointX) {
       cx = viewPointX;
@@ -2221,14 +2225,21 @@ public class MapPanel extends JPanel {
   }
 
   /**
-   * Get history coordinates.
-   * @return Coordinates
+   * Move history view towards targeted decomposed Coordinate.
+   * @param targetX Coordinate's X
+   * @param targetY Coordinate's Y
    */
-  public Coordinate getHistoryCoordinates() {
-    if (historyCoordinates == null) {
-      historyCoordinates = new Coordinate(15, 15);
+  public void moveHistoryTowards(final int targetX, final int targetY) {
+    if (targetX > historyCoordX) {
+      historyCoordX++;
+    } else if (targetX < historyCoordX) {
+      historyCoordX--;
     }
-    return historyCoordinates;
+    if (targetY > historyCoordY) {
+      historyCoordY++;
+    } else if (targetY < historyCoordY) {
+      historyCoordY--;
+    }
   }
 
   /**

--- a/src/main/java/org/openRealmOfStars/player/fleet/Fleet.java
+++ b/src/main/java/org/openRealmOfStars/player/fleet/Fleet.java
@@ -305,7 +305,7 @@ public class Fleet {
    * @return fleet's coordinate
    */
   public Coordinate getCoordinate() {
-    return new Coordinate(coordinate);
+    return coordinate;
   }
 
   /**

--- a/src/main/java/org/openRealmOfStars/starMap/Coordinate.java
+++ b/src/main/java/org/openRealmOfStars/starMap/Coordinate.java
@@ -2,6 +2,7 @@ package org.openRealmOfStars.starMap;
 /*
  * Open Realm of Stars game project
  * Copyright (C) 2016-2018 Tuomo Untinen
+ * Copyright (C) 2023 BottledByte
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -18,9 +19,8 @@ package org.openRealmOfStars.starMap;
  */
 
 /**
- *
- * Coordinate
- *
+ * Coordinate on a StarMap.
+ * Objects of this class are immutable.
  */
 public class Coordinate {
 
@@ -29,21 +29,13 @@ public class Coordinate {
     /** The Y value of the coordinate */
     private int y;
 
-    /**
-     * Direction up
-     */
+    /** Direction up */
     public static final int UP = 0;
-    /**
-     * Direction right
-     */
+    /** Direction right */
     public static final int RIGHT = 2;
-    /**
-     * Direction down
-     */
+    /** Direction down */
     public static final int DOWN = 4;
-    /**
-     * Direction left
-     */
+    /** Direction left */
     public static final int LEFT = 6;
 
     /**
@@ -87,27 +79,11 @@ public class Coordinate {
     }
 
     /**
-     * Set the X value of the coordinate
-     * @param x the X value of the coordinate
-     */
-    public void setX(final int x) {
-        this.x = x;
-    }
-
-    /**
      * Get the Y value ot the coordinate
      * @return the Y value ot the coordinate
      */
     public int getY() {
         return y;
-    }
-
-    /**
-     * Set the Y value of the coordinate
-     * @param y the Y value of the coordinate
-     */
-    public void setY(final int y) {
-        this.y = y;
     }
 
     /**
@@ -155,20 +131,26 @@ public class Coordinate {
       return false;
     }
 
-    /**
-     * Move coordinate towards target. Useful for map scrolling.
-     * @param target Coordinate
-     */
-    public void moveTowards(final Coordinate target) {
-      if (target.getX() > x) {
-        x++;
-      } else if (target.getX() < x) {
-        x--;
-      }
-      if (target.getY() > y) {
-        y++;
-      } else if (target.getY() < y) {
-        y--;
-      }
+    @Override
+    public int hashCode() {
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + x;
+      result = prime * result + y;
+      return result;
     }
+
+    @Override
+    public boolean equals(final Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if (!(obj instanceof Coordinate)) {
+        return false;
+      }
+
+      Coordinate other = (Coordinate) obj;
+      return sameAs(other);
+    }
+
 }

--- a/src/main/java/org/openRealmOfStars/starMap/planet/Planet.java
+++ b/src/main/java/org/openRealmOfStars/starMap/planet/Planet.java
@@ -1716,27 +1716,11 @@ public class Planet {
   }
 
   /**
-   * Set planet's X coordinate
-   * @param x X coordinate
-   */
-  public void setX(final int x) {
-    coordinate.setX(x);
-  }
-
-  /**
    * Get planet's Y coordinate
    * @return Y coordinate
    */
   public int getY() {
     return coordinate.getY();
-  }
-
-  /**
-   * Set planet's Y coordinate
-   * @param y Y coordinate
-   */
-  public void setY(final int y) {
-    coordinate.setY(y);
   }
 
   /**

--- a/src/test/java/org/openRealmOfStars/gui/mapPanel/MapPanelTest.java
+++ b/src/test/java/org/openRealmOfStars/gui/mapPanel/MapPanelTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
 import org.openRealmOfStars.game.Game;
-import org.openRealmOfStars.starMap.Coordinate;
 import org.openRealmOfStars.starMap.Route;
 
 /**
@@ -50,9 +49,7 @@ public class MapPanelTest {
     Route route = Mockito.mock(Route.class);
     panel.setRoute(route);
     assertEquals(route, panel.getRoute());
-    Coordinate coord = panel.getHistoryCoordinates();
-    assertEquals(15, coord.getX());
-    assertEquals(15, coord.getY());
+
     BufferedImage left = Mockito.mock(BufferedImage.class);
     assertEquals(null, panel.getLeftSpaceImage());
     panel.setLeftSpaceImage(left);
@@ -112,9 +109,7 @@ public class MapPanelTest {
     assertEquals(-48, panel.getOffsetY());
     assertEquals(1, panel.getViewPointX());
     assertEquals(1, panel.getViewPointY());
-    Coordinate coordinate = panel.getHistoryCoordinates();
-    assertEquals(15, coordinate.getX());
-    assertEquals(15, coordinate.getY());
+
     BufferedImage image = Mockito.mock(BufferedImage.class);
     assertNull(panel.getLeftSpaceImage());
     panel.setLeftSpaceImage(image);

--- a/src/test/java/org/openRealmOfStars/starMap/CoordinateTest.java
+++ b/src/test/java/org/openRealmOfStars/starMap/CoordinateTest.java
@@ -104,18 +104,4 @@ public class CoordinateTest {
         assertEquals(false, coordinate.sameAs(originalCoordinate));
         assertEquals(false, originalCoordinate.sameAs(coordinate));
     }
-
-    @Test
-    @Category(org.openRealmOfStars.BehaviourTest.class)
-    public void testCreateCoordinateFromAnotherWithoutSideEffect() {
-        Coordinate originalCoordinate = new Coordinate(10, 15);
-        Coordinate coordinate = new Coordinate(originalCoordinate);
-
-        originalCoordinate.setX(5);
-        originalCoordinate.setY(10);
-
-        assertNotEquals(originalCoordinate.getX(), coordinate.getX());
-        assertNotEquals(originalCoordinate.getY(), coordinate.getY());
-    }
-
 }

--- a/src/test/java/org/openRealmOfStars/starMap/SunTest.java
+++ b/src/test/java/org/openRealmOfStars/starMap/SunTest.java
@@ -18,7 +18,6 @@ package org.openRealmOfStars.starMap;
  */
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -67,24 +66,6 @@ public class SunTest {
         Sun sun = new Sun(coordinate, "Sun");
 
         assertEquals("Sun X:10 Y:15", sun.toString());
-    }
-
-    @Test
-    @Category(org.openRealmOfStars.BehaviourTest.class)
-    public void testSunCoordinateShouldChangeableWithSideEffect() {
-        Coordinate sunCoordinate = new Coordinate(10, 15);
-        Sun sun = new Sun(sunCoordinate, "Sun");
-
-        sunCoordinate.setX(5);
-        sunCoordinate.setY(10);
-
-        assertNotEquals(sun.getCenterCoordinate(), sunCoordinate);
-
-        Coordinate getSunCoordinate = sun.getCenterCoordinate();
-        getSunCoordinate.setX(5);
-        getSunCoordinate.setY(10);
-
-        assertNotEquals(sun.getCenterCoordinate(), getSunCoordinate);
     }
 
 }

--- a/src/test/java/org/openRealmOfStars/starMap/planet/PlanetTest.java
+++ b/src/test/java/org/openRealmOfStars/starMap/planet/PlanetTest.java
@@ -41,32 +41,6 @@ public class PlanetTest {
 
   @Test
   @Category(org.openRealmOfStars.BehaviourTest.class)
-  public void testPlanetCoordinateShouldChangeableWithSideEffect() {
-      Coordinate planetCoordinate = new Coordinate(10, 15);
-      Planet planet = new Planet(planetCoordinate, "Earth", 1, false);
-
-      assertEquals(-1, planet.getstartRealmIndex());
-      planet.setStartRealmIndex(2);
-      assertEquals(2, planet.getstartRealmIndex());
-      planetCoordinate.setX(5);
-      planetCoordinate.setY(10);
-
-      assertNotEquals(planet.getCoordinate(), planetCoordinate);
-
-      Coordinate getPlanetCoordinate = planet.getCoordinate();
-      getPlanetCoordinate.setX(5);
-      getPlanetCoordinate.setY(10);
-
-      assertNotEquals(planet.getCoordinate(), getPlanetCoordinate);
-      assertEquals(0, planet.getFleetCapacityBonus());
-      planet.addBuilding(BuildingFactory.createByName("Barracks"));
-      assertEquals(1, planet.getFleetCapacityBonus());
-      planet.addBuilding(BuildingFactory.createByName("Space port"));
-      assertEquals(2, planet.getFleetCapacityBonus());
-  }
-
-  @Test
-  @Category(org.openRealmOfStars.BehaviourTest.class)
   public void testPlanetPopulationGrowthAndBuilding() {
     Coordinate planetCoordinate = new Coordinate(10, 15);
     Planet planet = new Planet(planetCoordinate, "Earth", 1, false);


### PR DESCRIPTION
See #662 

The need for mutability functions was only because of 1 usage in GUI and several usages in tests.
GUI was changed to use primitives, tests were removed.

Coordinate now properly implements hashCode() and equals().

Also remove useless allocation of Coordinate in Fleet.