### PR TITLE
Remove Coordinate cloning

### DIFF
--- a/src/main/java/org/openRealmOfStars/ai/mission/Mission.java
+++ b/src/main/java/org/openRealmOfStars/ai/mission/Mission.java
@@ -120,11 +120,7 @@ public class Mission {
    * @param coordinate Target coordinate
    */
   public void setTarget(final Coordinate coordinate) {
-    if (coordinate != null) {
-      targetCoordinate = new Coordinate(coordinate);
-    } else {
-      targetCoordinate = null;
-    }
+    targetCoordinate = coordinate;
   }
 
   /**

--- a/src/main/java/org/openRealmOfStars/player/fleet/Fleet.java
+++ b/src/main/java/org/openRealmOfStars/player/fleet/Fleet.java
@@ -287,7 +287,7 @@ public class Fleet {
    * @param pos Fleet's coordinate
    */
   public void setPos(final Coordinate pos) {
-    this.coordinate = new Coordinate(pos);
+    this.coordinate = pos;
   }
 
   /**

--- a/src/main/java/org/openRealmOfStars/player/message/Message.java
+++ b/src/main/java/org/openRealmOfStars/player/message/Message.java
@@ -243,7 +243,7 @@ public class Message {
    * @param coordinate coordinate
    */
   public void setCoordinate(final Coordinate coordinate) {
-    this.coordinate = new Coordinate(coordinate);
+    this.coordinate = coordinate;
   }
 
   /**

--- a/src/main/java/org/openRealmOfStars/player/ship/Ship.java
+++ b/src/main/java/org/openRealmOfStars/player/ship/Ship.java
@@ -2274,7 +2274,7 @@ private int increaseHitChanceByComponent() {
           tradeCoordinates = planet.getCoordinate();
         }
       } else {
-        tradeCoordinates = new Coordinate(planet.getCoordinate());
+        tradeCoordinates = planet.getCoordinate();
         if (planet.getPlanetPlayerInfo() != null
             && planet.getPlanetPlayerInfo() == trader) {
           setFlag(FLAG_MERCHANT_LEFT_HOMEWORLD, true);

--- a/src/main/java/org/openRealmOfStars/starMap/Coordinate.java
+++ b/src/main/java/org/openRealmOfStars/starMap/Coordinate.java
@@ -25,9 +25,9 @@ package org.openRealmOfStars.starMap;
 public class Coordinate {
 
     /** The X value of the coordinate */
-    private int x;
+    private final int x;
     /** The Y value of the coordinate */
-    private int y;
+    private final int y;
 
     /** Direction up */
     public static final int UP = 0;
@@ -49,14 +49,6 @@ public class Coordinate {
     }
 
     /**
-     * Constructor for Coordinate
-     * @param coordinate The coordinate to copy it
-     */
-    public Coordinate(final Coordinate coordinate) {
-        this(coordinate.getX(), coordinate.getY());
-    }
-
-    /**
      * Get new coordinate from old one according the direction
      * @param direction UP, RIGHT, DOWN, LEFT are allowd
      * @return New coordinate according direction or old one
@@ -67,9 +59,10 @@ public class Coordinate {
         case RIGHT: return new Coordinate(getX() + 1, getY());
         case DOWN: return new Coordinate(getX(), getY() + 1);
         case LEFT: return new Coordinate(getX() - 1, getY());
-        default: return new Coordinate(this);
+        default: return this;
       }
     }
+
     /**
      * Get the X value ot the coordinate
      * @return the X value ot the coordinate
@@ -92,8 +85,8 @@ public class Coordinate {
      * @return the distance
      */
     public double calculateDistance(final Coordinate otherCoordinate) {
-        int xDistance = Math.abs(otherCoordinate.getX() - getX());
-        int yDistance = Math.abs(otherCoordinate.getY() - getY());
+        int xDistance = otherCoordinate.x - x;
+        int yDistance = otherCoordinate.y - y;
         return Math.sqrt(xDistance * xDistance + yDistance * yDistance);
     }
 
@@ -105,12 +98,7 @@ public class Coordinate {
      * @return true if valid and false if invalid
      */
     public boolean isValidCoordinate(final Coordinate maxCoordinate) {
-        if (getX() >= 0 && getY() >= 0
-                && getX() < maxCoordinate.getX()
-                && getY() < maxCoordinate.getY()) {
-            return true;
-        }
-        return false;
+        return x >= 0 && y >= 0 && x < maxCoordinate.x && y < maxCoordinate.y;
     }
 
     @Override

--- a/src/main/java/org/openRealmOfStars/starMap/StarMap.java
+++ b/src/main/java/org/openRealmOfStars/starMap/StarMap.java
@@ -1249,7 +1249,7 @@ public class StarMap {
         fleet.setName(playerInfo.getFleets().generateUniqueName(
             ship.getName()));
         Mission mission = new Mission(MissionType.ROAM,
-            MissionPhase.TREKKING, new Coordinate(fleet.getCoordinate()));
+            MissionPhase.TREKKING, fleet.getCoordinate());
         mission.setFleetName(fleet.getName());
         playerInfo.getMissions().add(mission);
       }

--- a/src/main/java/org/openRealmOfStars/starMap/Sun.java
+++ b/src/main/java/org/openRealmOfStars/starMap/Sun.java
@@ -43,7 +43,7 @@ public class Sun {
    * @param name Sun name if null then random generator applied
    */
   public Sun(final Coordinate coordinate, final String name) {
-    this.centerCoordinate = new Coordinate(coordinate);
+    this.centerCoordinate = coordinate;
     this.name = name;
   }
 
@@ -86,7 +86,7 @@ public class Sun {
    * @return Sun's Center coordinate
    */
   public Coordinate getCenterCoordinate() {
-    return new Coordinate(centerCoordinate);
+    return centerCoordinate;
   }
 
   @Override

--- a/src/main/java/org/openRealmOfStars/starMap/planet/Planet.java
+++ b/src/main/java/org/openRealmOfStars/starMap/planet/Planet.java
@@ -1735,7 +1735,7 @@ public class Planet {
    * @return Coordinate
    */
   public Coordinate getCoordinate() {
-    return new Coordinate(coordinate);
+    return coordinate;
   }
 
   /**
@@ -1743,7 +1743,7 @@ public class Planet {
    * @param coordinate Planet's coordinate
    */
   public void setCoordinate(final Coordinate coordinate) {
-    this.coordinate = new Coordinate(coordinate);
+    this.coordinate = coordinate;
   }
 
   /**

--- a/src/test/java/org/openRealmOfStars/starMap/CoordinateTest.java
+++ b/src/test/java/org/openRealmOfStars/starMap/CoordinateTest.java
@@ -41,16 +41,6 @@ public class CoordinateTest {
 
     @Test
     @Category(org.openRealmOfStars.UnitTest.class)
-    public void testCreateCoordinateFromAnother() {
-        Coordinate originalCoordinate = new Coordinate(10, 15);
-        Coordinate coordinate = new Coordinate(originalCoordinate);
-
-        assertEquals(originalCoordinate.getX(), coordinate.getX());
-        assertEquals(originalCoordinate.getY(), coordinate.getY());
-    }
-
-    @Test
-    @Category(org.openRealmOfStars.UnitTest.class)
     public void testCreateCoordinateUp() {
         int x = 10;
         int y = 15;


### PR DESCRIPTION
After implementing GH-662 , `Coordinate` is immutable and does not need to be "cloned" to prevent side-effects.