### PR TITLE
Add RaceTrait for races with constructed population

### DIFF
--- a/src/main/java/org/openRealmOfStars/player/race/RaceTrait.java
+++ b/src/main/java/org/openRealmOfStars/player/race/RaceTrait.java
@@ -67,6 +67,11 @@ public final class RaceTrait {
       "NO_HEIRS", "No heirs",
       "Race has unusual birth process, to which it is"
           + " not possible to apply concept of parental heritage.");
+  /** Race can breed by explictly constructing it's own population. */
+  public static final RaceTrait CONSTRUCTED_POP = new RaceTrait(
+      "CONSTRUCTED_POP", "Constructed",
+      "Breeds by external process, where individuals "
+          + " are \"constructed\" in some way.");
 
   /** ID of the trait */
   private String traitId;

--- a/src/main/java/org/openRealmOfStars/player/race/SpaceRace.java
+++ b/src/main/java/org/openRealmOfStars/player/race/SpaceRace.java
@@ -48,7 +48,8 @@ public enum SpaceRace {
   MECHIONS(1, "Mechions", "Mechion",
           "Mechanical beings whom do not eat food.\n"
         + "Each population must be built.",
-        RaceTrait.ROBOTIC, RaceTrait.ENERGY_POWERED, RaceTrait.NO_HEIRS),
+        RaceTrait.ROBOTIC, RaceTrait.ENERGY_POWERED, RaceTrait.NO_HEIRS,
+        RaceTrait.CONSTRUCTED_POP),
   /**
    * Aggressive and warmongering spieces.
    */
@@ -172,7 +173,7 @@ public enum SpaceRace {
    */
   SYNTHDROIDS(16, "Synthdroids", "Synthdroid", "Artificial beings that eat only"
       + " small amount of food. Each population must be built.",
-      RaceTrait.ROBOTIC, RaceTrait.NO_HEIRS),
+      RaceTrait.ROBOTIC, RaceTrait.NO_HEIRS, RaceTrait.CONSTRUCTED_POP),
   /**
    * Alonian realm always starts without homeplanet. How ever they get higher
    * starting technology and have special ability where single colony ship

--- a/src/main/java/org/openRealmOfStars/starMap/planet/Planet.java
+++ b/src/main/java/org/openRealmOfStars/starMap/planet/Planet.java
@@ -1776,33 +1776,36 @@ public class Planet {
     if (tmp2 != null && !exceedRadiation()) {
       result.add(tmp2);
     }
+
+    if (planetOwnerInfo != null) {
+      SpaceRace planetRace = planetOwnerInfo.getRace();
+      // Population can construct itself
+      // Lookup valid construction project for race based on singular name
+      if (planetRace.hasTrait(RaceTrait.CONSTRUCTED_POP.getId())
+          && getTotalPopulation() < getPopulationLimit()) {
+        var popProjectId = planetRace.getNameSingle() + " citizen";
+        var popProject = ConstructionFactory.createByName(popProjectId);
+        if (popProject != null) {
+          if (!exceedRadiation()) {
+            result.add(popProject);
+          }
+        } else {
+          ErrorLogger.log("Could not find population construction project"
+              + " for race: " + planetRace.getName());
+        }
+      }
+      // Population is eating food, add basic farms
+      if (planetRace.isEatingFood()) {
+        var farmBuilding = BuildingFactory.createByName("Basic farm");
+        if (farmBuilding != null && !exceedRadiation()) {
+          result.add(farmBuilding);
+        }
+      }
+    }
+
     Building tmp = BuildingFactory.createByName("Basic mine");
     if (tmp != null) {
       result.add(tmp);
-    }
-    if (planetOwnerInfo != null
-        && planetOwnerInfo.getRace() == SpaceRace.MECHIONS
-        && getTotalPopulation() < getPopulationLimit()) {
-      tmp2 = ConstructionFactory
-          .createByName(ConstructionFactory.MECHION_CITIZEN);
-      if (tmp2 != null && !exceedRadiation()) {
-        result.add(tmp2);
-      }
-    } else if (planetOwnerInfo != null
-        && !planetOwnerInfo.getRace().isLithovorian()) {
-      tmp = BuildingFactory.createByName("Basic farm");
-      if (tmp != null && !exceedRadiation()) {
-        result.add(tmp);
-      }
-      if (planetOwnerInfo != null
-        && planetOwnerInfo.getRace() == SpaceRace.SYNTHDROIDS
-        && getTotalPopulation() < getPopulationLimit()) {
-        tmp2 = ConstructionFactory
-            .createByName(ConstructionFactory.SYNTHDROID_CITIZEN);
-        if (tmp2 != null && !exceedRadiation()) {
-          result.add(tmp2);
-        }
-      }
     }
     tmp = BuildingFactory.createByName("Basic factory");
     if (tmp != null) {

--- a/src/test/java/org/openRealmOfStars/ai/planet/PlanetHandlingTest.java
+++ b/src/test/java/org/openRealmOfStars/ai/planet/PlanetHandlingTest.java
@@ -389,8 +389,8 @@ public class PlanetHandlingTest {
     assertEquals(7, scores.length);
     assertEquals(-1, scores[0]);
     assertEquals(-1, scores[1]);
-    assertEquals(99, scores[2]);
-    assertEquals(39, scores[3]);
+    assertEquals(39, scores[2]);
+    assertEquals(99, scores[3]);
     assertEquals(99, scores[4]);
     assertEquals(-1, scores[6]);
     planet.addBuilding(createBasicMine());
@@ -400,8 +400,8 @@ public class PlanetHandlingTest {
     assertEquals(7, scores.length);
     assertEquals(-1, scores[0]);
     assertEquals(-1, scores[1]);
-    assertEquals(79, scores[2]);
-    assertEquals(39, scores[3]);
+    assertEquals(39, scores[2]);
+    assertEquals(79, scores[3]);
     assertEquals(99, scores[4]);
     assertEquals(-1, scores[6]);
     planet.addBuilding(createBasicFactory());
@@ -411,8 +411,8 @@ public class PlanetHandlingTest {
     assertEquals(7, scores.length);
     assertEquals(-1, scores[0]);
     assertEquals(-1, scores[1]);
-    assertEquals(99, scores[2]);
-    assertEquals(39, scores[3]);
+    assertEquals(39, scores[2]);
+    assertEquals(99, scores[3]);
     assertEquals(99, scores[4]);
     assertEquals(-1, scores[6]);
     planet.addBuilding(createBasicMine());
@@ -422,8 +422,8 @@ public class PlanetHandlingTest {
     assertEquals(7, scores.length);
     assertEquals(-1, scores[0]);
     assertEquals(-1, scores[1]);
-    assertEquals(79, scores[2]);
-    assertEquals(39, scores[3]);
+    assertEquals(39, scores[2]);
+    assertEquals(79, scores[3]);
     assertEquals(99, scores[4]);
     assertEquals(-1, scores[6]);
     planet.addBuilding(createBasicFactory());
@@ -433,8 +433,8 @@ public class PlanetHandlingTest {
     assertEquals(7, scores.length);
     assertEquals(-1, scores[0]);
     assertEquals(-1, scores[1]);
-    assertEquals(99, scores[2]);
-    assertEquals(39, scores[3]);
+    assertEquals(39, scores[2]);
+    assertEquals(99, scores[3]);
     assertEquals(59, scores[4]);
     assertEquals(-1, scores[6]);
 /*    for (int i = 0; i < constructions.length; i++) {
@@ -484,8 +484,8 @@ public class PlanetHandlingTest {
     assertEquals(7, scores.length);
     assertEquals(-1, scores[0]);
     assertEquals(-1, scores[1]);
-    assertEquals(119, scores[2]);
-    assertEquals(49, scores[3]);
+    assertEquals(49, scores[2]);
+    assertEquals(119, scores[3]);
     assertEquals(139, scores[4]);
     assertEquals(-1, scores[6]);
     planet.addBuilding(createBasicFactory());
@@ -500,8 +500,8 @@ public class PlanetHandlingTest {
     assertEquals(8, scores.length);
     assertEquals(-1, scores[0]);
     assertEquals(-1, scores[1]);
-    assertEquals(134, scores[2]);
-    assertEquals(49, scores[3]);
+    assertEquals(49, scores[2]);
+    assertEquals(134, scores[3]);
     assertEquals(19, scores[4]);
     assertEquals(59, scores[5]);
     assertEquals(-1, scores[7]);
@@ -515,8 +515,8 @@ public class PlanetHandlingTest {
     assertEquals(8, scores.length);
     assertEquals(-1, scores[0]);
     assertEquals(-1, scores[1]);
-    assertEquals(119, scores[2]);
-    assertEquals(49, scores[3]);
+    assertEquals(49, scores[2]);
+    assertEquals(119, scores[3]);
     assertEquals(119, scores[4]);
     assertEquals(99, scores[5]);
     assertEquals(-1, scores[7]);
@@ -527,8 +527,8 @@ public class PlanetHandlingTest {
     assertEquals(8, scores.length);
     assertEquals(-1, scores[0]);
     assertEquals(-1, scores[1]);
-    assertEquals(89, scores[2]);
-    assertEquals(59, scores[3]);
+    assertEquals(59, scores[2]);
+    assertEquals(89, scores[3]);
     assertEquals(119, scores[4]);
     assertEquals(109, scores[5]);
     assertEquals(-1, scores[7]);
@@ -539,8 +539,8 @@ public class PlanetHandlingTest {
     assertEquals(8, scores.length);
     assertEquals(-1, scores[0]);
     assertEquals(-1, scores[1]);
-    assertEquals(89, scores[2]);
-    assertEquals(59, scores[3]);
+    assertEquals(59, scores[2]);
+    assertEquals(89, scores[3]);
     assertEquals(119, scores[4]);
     assertEquals(59, scores[5]);
     assertEquals(-1, scores[7]);
@@ -551,8 +551,8 @@ public class PlanetHandlingTest {
     assertEquals(8, scores.length);
     assertEquals(-1, scores[0]);
     assertEquals(-1, scores[1]);
-    assertEquals(109, scores[2]);
-    assertEquals(59, scores[3]);
+    assertEquals(59, scores[2]);
+    assertEquals(109, scores[3]);
     assertEquals(69, scores[4]);
     assertEquals(59, scores[5]);
     assertEquals(-1, scores[7]);
@@ -565,8 +565,8 @@ public class PlanetHandlingTest {
     assertEquals(9, scores.length);
     assertEquals(-1, scores[0]);
     assertEquals(-1, scores[1]);
-    assertEquals(39, scores[2]);
-    assertEquals(59, scores[3]);
+    assertEquals(59, scores[2]);
+    assertEquals(39, scores[3]);
     assertEquals(69, scores[4]);
     assertEquals(59, scores[5]);
     assertEquals(79, scores[6]);
@@ -585,8 +585,8 @@ public class PlanetHandlingTest {
     assertEquals(9, scores.length);
     assertEquals(-1, scores[0]);
     assertEquals(-1, scores[1]);
-    assertEquals(39, scores[2]);
-    assertEquals(59, scores[3]);
+    assertEquals(59, scores[2]);
+    assertEquals(39, scores[3]);
     assertEquals(69, scores[4]);
     assertEquals(59, scores[5]);
     assertEquals(113, scores[6]);


### PR DESCRIPTION
Add `RaceTrait` `CONSTRUCTED_POP` that allows race's population to be created with construction project.
Related to GH-673.

It works by looking-up `Construction` project for population based on race's name, as `RaceTrait` application to `SpaceRace` cannot have additional data - in this case, it *could have been* the population build project ID(s).

Since construction projects can be in theory also procedurally generated and/or defined in data files, this is quite extensible. Only limitation I can think of is that it does not allow to have multiple "population build processes" per race in current design... but it's not impossible :smirk: .

**This trait does not imply that the population cannot grow in some other way!** This is to keep doors open for races that for example breed very slowly, but can **additionally** build their population naturally (not via theoretical researched cloning tech). Furthermore, "no pop growth" is expressed by `SpaceRace`'s attribute of growth speed, which can be zero.

To throw in some ideas for races which could have both constructed and naturally grown population,
I can imagine some plant/fungus-like, collective life-form, that naturally grows by itself, but can concentrate resources in creating new "collective" or something.

I also changed ordering of possible construction projects.
Code is more clear, plus I disliked previous one, where "Basic mine" was above "Citizens" (which are "special" projects). Behavioral tests were adjusted for this.