### PR TITLE
Add support for "resource shadowing" (and rewrite Font handling)

### DIFF
--- a/src/main/java/org/openRealmOfStars/utilities/DataSources.java
+++ b/src/main/java/org/openRealmOfStars/utilities/DataSources.java
@@ -1,0 +1,128 @@
+package org.openRealmOfStars.utilities;
+/*
+ * Open Realm of Stars game project
+ * Copyright (C) 2023 BottledByte
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see http://www.gnu.org/licenses/
+ */
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Class for looking-up files in various data sources.
+ *
+ * <p>
+ * Intended to allow (rather basic) modding.
+ * Game data can be "shadowed" by data with same name
+ * in other source, which has higher priority.
+ * In case the data is not found in external source,
+ * it will fallback to trying to load it from game JAR.
+ * </p>
+ *
+ * Only alternative external data source is currenly
+ * <i>"gamedata" directory, in directory with game JAR</i>.
+ */
+public final class DataSources {
+  /** The Singleton */
+  private static final DataSources SINGLETON = new DataSources();
+
+  /**
+   * Search for requested file with relativeName in all sources,
+   * prefer external, fallback to JAR.
+   * @param relativeName data "name"
+   * @return URL to data or empty
+   */
+  public static Optional<URL> getDataUrl(final String relativeName) {
+    return SINGLETON.getUrl(relativeName);
+  }
+
+  /** List of paths to try before fallback */
+  private ArrayList<String> shadowPaths;
+
+  /** Construct new object */
+  private DataSources() {
+    this.shadowPaths = new ArrayList<>();
+
+    String srcJarPath = null;
+    try {
+      srcJarPath = DataSources.class.getProtectionDomain()
+          .getCodeSource().getLocation().toURI().getPath();
+    } catch (URISyntaxException e) {
+      ErrorLogger.log(e);
+    } catch (SecurityException e) {
+      ErrorLogger.log(e);
+    }
+    // Probably run in aan unusual or strict environment
+    // Don't add relative external data directory
+    if (srcJarPath == null) {
+      ErrorLogger.log("Could not locate where the game JAR is");
+      return;
+    }
+
+    // Information about what data dir will be used does not hurt
+    ErrorLogger.debug("External data dir at: " + srcJarPath);
+
+    var srcJarDir = new File(srcJarPath).getParent();
+    addSource(srcJarDir + "/gamedata");
+  }
+
+  /**
+   *
+   * @param extSourcePath path to add
+   */
+  private void addSource(final String extSourcePath) {
+    shadowPaths.add(0, extSourcePath);
+  }
+
+  /**
+   * Search for requested data with relativeName in all sources,
+   * prefer external, fallback to JAR.
+   * @param relativeName data "name"
+   * @return URL to data or empty
+   */
+  private Optional<URL> getUrl(final String relativeName) {
+    Objects.requireNonNull(relativeName);
+    // Search in external data directories first
+    for (var basePath : shadowPaths) {
+      final var file = new File(basePath, relativeName);
+      if (file.exists() && file.isFile()) {
+        try {
+          return Optional.of(file.toURI().toURL());
+        } catch (MalformedURLException e) {
+          ErrorLogger.log(e);
+          return Optional.empty();
+        }
+      }
+    }
+
+    // Search in JAR file resources as fallback
+    // TODO: This if a compatibility hack, to work with rest of the codebase
+    var resName = relativeName;
+    if (resName.startsWith("/")) {
+      resName = resName.substring(1);
+    }
+
+    final var resourceUrl = DataSources.class.getResource("/" + resName);
+    if (resourceUrl == null) {
+      ErrorLogger.log("Failed to locate file in JAR: " + relativeName);
+    }
+    return Optional.ofNullable(resourceUrl);
+  }
+}

--- a/src/main/java/org/openRealmOfStars/utilities/IOUtilities.java
+++ b/src/main/java/org/openRealmOfStars/utilities/IOUtilities.java
@@ -30,8 +30,6 @@ import java.nio.charset.StandardCharsets;
 
 import javax.imageio.ImageIO;
 
-import org.openRealmOfStars.gui.util.GuiStatics;
-
 /**
  *
  * Generic IO Utilities
@@ -52,8 +50,8 @@ public final class IOUtilities {
    * @return BufferedImage if succeed null if fails
    */
   public static BufferedImage loadImage(final String urlToImage) {
-    URL imageUrl = GuiStatics.class.getResource(urlToImage);
-    return loadImage(imageUrl);
+    URL imageUrlOpt = DataSources.getDataUrl(urlToImage).orElse(null);
+    return loadImage(imageUrlOpt);
   }
 
   /**


### PR DESCRIPTION
Add ability to replace files from JAR file with data placed into directory `gamedata`, which must be next to the JAR file with game. This feature is dubbed "shadowing". **Essential for basic modding** and data-driven design. "Common sense-grade" prerequisite for GH-666.

Allow shadowing of game Image resources.

*Scrap that atrocious Font code and rewrite it from scratch.* Should be a separate PR, but I refuse to split my work again to tiny pieces, and sequentially submit PRs. :neutral_face:  

- **Fonts can use dynamic scaling (in %).** (internal only, old "larger fonts" switch left for compatibility)
   Potentially massive improvement for player experience (UX).
   I always have to play with "larger fonts" turned on and it is still unreadable :unamused: .
   I chose a sane size multiplier in order to not break the GUI much (which does not handle font scaling... or any scaling)
- **Fonts can be hot-swapped at runtime for different ones** (thanks to shadowing and proper cache).
   Player can bring their own fonts and developer does not have to recompile when tweaking GUI's fonts.
- **Fixed something between 1-6 Font bugs caused by broken copy-paste.**
   I was wondering why "larger fonts" did not work as expected. There were bad variable assignments, bizarre defaults...
   All fixed. Probably I put there my own bugs, but they are nicely trackable, as there is now 12x times less copypaste. :upside_down_face: 

@tuomount you can try to add (at least limited) GUI support for the new Font dynamic scaling, for said massive UX boost.
I refuse to touch Swing :smile: . Also, we should not have conflicts in that case, since I mostly ignore GUI code.

***In case you dislike the new Font refactor/improvements, discard that commit***.
*You can force-push to my branch (as usual) and hard-reset the last commit.*
But I can only recommend accepting the changes :slightly_smiling_face: .

Additionally, I am already depending on the "resource shadowing" feature in my continuation of work on GH-673 and soon in my prototypes for GH-676. It does not make much sense to me to offload new game definitions into data when I cannot easily override said data externally to get "modding support".