### PR TITLE
Dehardcode RaceTraits to JSON

### DIFF
--- a/src/main/java/org/openRealmOfStars/ai/mission/MissionList.java
+++ b/src/main/java/org/openRealmOfStars/ai/mission/MissionList.java
@@ -19,7 +19,7 @@ package org.openRealmOfStars.ai.mission;
 
 import org.openRealmOfStars.player.PlayerInfo;
 import org.openRealmOfStars.player.fleet.Fleet;
-import org.openRealmOfStars.player.race.RaceTrait;
+import org.openRealmOfStars.player.race.trait.TraitIds;
 import org.openRealmOfStars.starMap.Coordinate;
 import org.openRealmOfStars.starMap.StarMap;
 import org.openRealmOfStars.starMap.planet.Planet;
@@ -190,7 +190,7 @@ public class MissionList {
             value = value - 20;
           }
         }
-        if (info.getRace().hasTrait(RaceTrait.RADIOSYNTHESIS.getId())) {
+        if (info.getRace().hasTrait(TraitIds.RADIOSYNTHESIS)) {
           value = value + colonPlanet.getRadiationLevel() * 2;
         } else {
           value = value - colonPlanet.getRadiationLevel();

--- a/src/main/java/org/openRealmOfStars/ai/planet/PlanetHandling.java
+++ b/src/main/java/org/openRealmOfStars/ai/planet/PlanetHandling.java
@@ -33,8 +33,8 @@ import org.openRealmOfStars.player.government.GovernmentType;
 import org.openRealmOfStars.player.leader.LeaderUtility;
 import org.openRealmOfStars.player.message.Message;
 import org.openRealmOfStars.player.message.MessageType;
-import org.openRealmOfStars.player.race.RaceTrait;
 import org.openRealmOfStars.player.race.SpaceRace;
+import org.openRealmOfStars.player.race.trait.TraitIds;
 import org.openRealmOfStars.player.ship.Ship;
 import org.openRealmOfStars.player.ship.ShipHullType;
 import org.openRealmOfStars.player.tech.TechType;
@@ -2391,7 +2391,7 @@ public final class PlanetHandling {
     int happy = planet.calculateHappiness();
     int food = planet.getFoodProdByPlanetAndBuildings();
 
-    if (info.getRace().hasTrait(RaceTrait.RADIOSYNTHESIS.getId())) {
+    if (info.getRace().hasTrait(TraitIds.RADIOSYNTHESIS)) {
       int rad = planet.getRadiationLevel();
       food += Math.min(rad, totalPop);
     }

--- a/src/main/java/org/openRealmOfStars/game/Game.java
+++ b/src/main/java/org/openRealmOfStars/game/Game.java
@@ -2407,6 +2407,8 @@ public class Game implements ActionListener {
    * @param args from Command line
    */
   public static void main(final String[] args) {
+    // TODO: Remove when SpaceRaces are dehardcoded
+    SpaceRace.initialize();
     MusicPlayer.setMusicEnabled(true);
     SoundPlayer.setSoundEnabled(true);
     if (args.length > 0 && args[0].equals("--wiki-research")) {

--- a/src/main/java/org/openRealmOfStars/game/state/AITurnView.java
+++ b/src/main/java/org/openRealmOfStars/game/state/AITurnView.java
@@ -70,8 +70,8 @@ import org.openRealmOfStars.player.leader.Perk;
 import org.openRealmOfStars.player.leader.stats.StatType;
 import org.openRealmOfStars.player.message.Message;
 import org.openRealmOfStars.player.message.MessageType;
-import org.openRealmOfStars.player.race.RaceTrait;
 import org.openRealmOfStars.player.race.SpaceRace;
+import org.openRealmOfStars.player.race.trait.TraitIds;
 import org.openRealmOfStars.player.ship.Ship;
 import org.openRealmOfStars.player.ship.ShipStat;
 import org.openRealmOfStars.player.ship.generator.ShipGenerator;
@@ -3189,7 +3189,7 @@ public class AITurnView extends BlackPanel {
               && heirs == 1) {
             chance = 4;
           }
-          if (leader.getRace().hasTrait(RaceTrait.NO_HEIRS.getId())) {
+          if (leader.getRace().hasTrait(TraitIds.NO_HEIRS)) {
             // Races without concept of parental heritage do not get heirs
             chance = 0;
           }

--- a/src/main/java/org/openRealmOfStars/game/state/PlanetListView.java
+++ b/src/main/java/org/openRealmOfStars/game/state/PlanetListView.java
@@ -36,7 +36,7 @@ import org.openRealmOfStars.gui.labels.UncolonizedPlanetInfoLabel;
 import org.openRealmOfStars.gui.panels.BlackPanel;
 import org.openRealmOfStars.gui.util.GuiStatics;
 import org.openRealmOfStars.player.PlayerInfo;
-import org.openRealmOfStars.player.race.RaceTrait;
+import org.openRealmOfStars.player.race.trait.TraitIds;
 import org.openRealmOfStars.starMap.Coordinate;
 import org.openRealmOfStars.starMap.StarMap;
 import org.openRealmOfStars.starMap.planet.Planet;
@@ -185,7 +185,7 @@ public class PlanetListView extends BlackPanel {
         final var planetRad = planet.getRadiationLevel();
         // Races with radiosythesis rate planets with radiation more favorably
         // NOTE: Why is planet-rating logic here, in GUI code???
-        if (race.hasTrait(RaceTrait.RADIOSYNTHESIS.getId())) {
+        if (race.hasTrait(TraitIds.RADIOSYNTHESIS)) {
           if (planetRad > raceMaxRad) {
             value -= (planetRad - raceMaxRad) * 2;
           } else {

--- a/src/main/java/org/openRealmOfStars/player/race/SpaceRace.java
+++ b/src/main/java/org/openRealmOfStars/player/race/SpaceRace.java
@@ -28,6 +28,7 @@ import org.openRealmOfStars.gui.util.GuiStatics;
 import org.openRealmOfStars.player.PlayerColor;
 import org.openRealmOfStars.player.diplomacy.Attitude;
 import org.openRealmOfStars.player.race.trait.RaceTrait;
+import org.openRealmOfStars.player.race.trait.TraitFactory;
 import org.openRealmOfStars.player.race.trait.TraitIds;
 import org.openRealmOfStars.starMap.planet.PlanetTypes;
 import org.openRealmOfStars.starMap.planet.WorldType;
@@ -49,9 +50,7 @@ public enum SpaceRace {
    */
   MECHIONS(1, "Mechions", "Mechion",
           "Mechanical beings whom do not eat food.\n"
-        + "Each population must be built.",
-        RaceTrait.ROBOTIC, RaceTrait.ENERGY_POWERED, RaceTrait.NO_HEIRS,
-        RaceTrait.CONSTRUCTED_POP),
+        + "Each population must be built."),
   /**
    * Aggressive and warmongering spieces.
    */
@@ -120,7 +119,7 @@ public enum SpaceRace {
           "Chiraloids are creatures with four arms and two legs.\n"
         + "They have hard exoskeleton. They also have special gland\n"
         + "which uses radioactivity to create nutrient. This is called\n"
-        + "radiosynthesis.", RaceTrait.RADIOSYNTHESIS),
+        + "radiosynthesis."),
   /**
    * Reborgians are organism combined with organic and robotic
    * parts. So they are cyborgs. They can synthesize any living space race
@@ -132,8 +131,7 @@ public enum SpaceRace {
       "Reborgians are organism combined with bionic and robotic "
       + "parts. So they are cyborgs. They can synthesize any living space race"
       + " to their own race, so they are fearful conquerors. They need only"
-      + " very little food surviving, but their reproduction is very slow.",
-      RaceTrait.NO_HEIRS),
+      + " very little food surviving, but their reproduction is very slow."),
   /**
    * Lithorians are creatures that eat metal instead of food. They have slow
    * grow rate and they have -2 population limit. They have
@@ -142,7 +140,7 @@ public enum SpaceRace {
   LITHORIANS(12, "Lithorians", "Lithorian",
       "Lithorians are creatures that eat metal instead of food. They have"
       + " slow grow rate and they have -2 population limit."
-      + " They have excellent ability to mine metal.", RaceTrait.LITHOVORIC),
+      + " They have excellent ability to mine metal."),
   /**
    * Alteirians are creatures that live in zero gravity. Because of this they
    * need special suites to move planet surface. Most of their time they
@@ -174,8 +172,7 @@ public enum SpaceRace {
    * Each population must be built. Alternative name Huskdroid.
    */
   SYNTHDROIDS(16, "Synthdroids", "Synthdroid", "Artificial beings that eat only"
-      + " small amount of food. Each population must be built.",
-      RaceTrait.ROBOTIC, RaceTrait.NO_HEIRS, RaceTrait.CONSTRUCTED_POP),
+      + " small amount of food. Each population must be built."),
   /**
    * Alonian realm always starts without homeplanet. How ever they get higher
    * starting technology and have special ability where single colony ship
@@ -186,6 +183,44 @@ public enum SpaceRace {
       + " homeplanet.\nHowever they get higher starting technology and have"
       + " special ability\nwhere single colony ship produces one research"
       + " point.\nAlso starbase's laboratories produces more research points.");
+
+  /**
+   * Explicitly (re)initialize SpaceRaces.
+   * Needed, because RaceTraits are loaded later than SpaceRaces.
+   * Trying to use TraitFactory in an enum constructor
+   * will result in a critical Java failure.
+   * TODO: Remove when SpaceRaces get dehardcoded.
+   */
+  public static void initialize() {
+    // Clear traits from races.
+    for (var race : values()) {
+      race.traits.clear();
+    }
+
+    // Add traits *that exist* to hardcoded list of races
+    TraitFactory.create(TraitIds.ROBOTIC).ifPresent(trait -> {
+      MECHIONS.addTrait(trait);
+      SYNTHDROIDS.addTrait(trait);
+    });
+    TraitFactory.create(TraitIds.LITHOVORIC).ifPresent(trait -> {
+      LITHORIANS.addTrait(trait);
+    });
+    TraitFactory.create(TraitIds.ENERGY_POWERED).ifPresent(trait -> {
+      MECHIONS.addTrait(trait);
+    });
+    TraitFactory.create(TraitIds.NO_HEIRS).ifPresent(trait -> {
+      MECHIONS.addTrait(trait);
+      REBORGIANS.addTrait(trait);
+      SYNTHDROIDS.addTrait(trait);
+    });
+    TraitFactory.create(TraitIds.CONSTRUCTED_POP).ifPresent(trait -> {
+      MECHIONS.addTrait(trait);
+      SYNTHDROIDS.addTrait(trait);
+    });
+    TraitFactory.create(TraitIds.RADIOSYNTHESIS).ifPresent(trait -> {
+      CHIRALOIDS.addTrait(trait);
+    });
+  }
 
   /**
    * Create space race

--- a/src/main/java/org/openRealmOfStars/player/race/SpaceRace.java
+++ b/src/main/java/org/openRealmOfStars/player/race/SpaceRace.java
@@ -27,6 +27,8 @@ import org.openRealmOfStars.audio.music.MusicPlayer;
 import org.openRealmOfStars.gui.util.GuiStatics;
 import org.openRealmOfStars.player.PlayerColor;
 import org.openRealmOfStars.player.diplomacy.Attitude;
+import org.openRealmOfStars.player.race.trait.RaceTrait;
+import org.openRealmOfStars.player.race.trait.TraitIds;
 import org.openRealmOfStars.starMap.planet.PlanetTypes;
 import org.openRealmOfStars.starMap.planet.WorldType;
 import org.openRealmOfStars.utilities.DiceGenerator;
@@ -1387,7 +1389,7 @@ public enum SpaceRace {
     if (isLithovorian()) {
       return false;
     }
-    if (hasTrait(RaceTrait.ENERGY_POWERED.getId())) {
+    if (hasTrait(TraitIds.ENERGY_POWERED)) {
       return false;
     }
 
@@ -1399,7 +1401,7 @@ public enum SpaceRace {
    * @return True if eating metal.
    */
   public boolean isLithovorian() {
-    return hasTrait(RaceTrait.LITHOVORIC.getId());
+    return hasTrait(TraitIds.LITHOVORIC);
   }
 
   /**
@@ -1407,7 +1409,7 @@ public enum SpaceRace {
    * @return True if robotic.
    */
   public boolean isRoboticRace() {
-    return hasTrait(RaceTrait.ROBOTIC.getId());
+    return hasTrait(TraitIds.ROBOTIC);
   }
 
   /**

--- a/src/main/java/org/openRealmOfStars/player/race/trait/RaceTrait.java
+++ b/src/main/java/org/openRealmOfStars/player/race/trait/RaceTrait.java
@@ -43,50 +43,9 @@ import org.openRealmOfStars.player.race.SpaceRace;
  * Situations like trait A conflicting with trait B,
  * but B NOT conficting with A should be avoided.
  * </p>
- * TODO: Dehardcode actual traits from here
  * @see SpaceRace
  */
 public final class RaceTrait {
-  /** Robotic */
-  public static final RaceTrait ROBOTIC = new RaceTrait(TraitIds.ROBOTIC,
-      "Robotic",
-      "Race is robotic.");
-  /**
-   * Eats minerals.
-   * Cannot be combined with ENERGY_POWERED.
-   */
-  public static final RaceTrait LITHOVORIC = new RaceTrait(TraitIds.LITHOVORIC,
-      "Lithovoric",
-      "Eats minerals instead of food.", "ENERGY_POWERED");
-  /**
-   * Eats energy (credits).
-   * Cannot be combined with LITHOVORIC.
-   */
-  public static final RaceTrait ENERGY_POWERED = new RaceTrait(
-      TraitIds.ENERGY_POWERED, "Powered",
-      "Consumes energy credits instead of food"
-          + " at a rate of 1 credit per 4 population.");
-  /** Concept of parental heritage is not applicable for the race. */
-  public static final RaceTrait NO_HEIRS = new RaceTrait(
-      TraitIds.NO_HEIRS, "No heirs",
-      "Race has unusual birth process, to which it is"
-          + " not possible to apply concept of parental heritage.");
-  /** Race can breed by explictly constructing it's own population. */
-  public static final RaceTrait CONSTRUCTED_POP = new RaceTrait(
-      TraitIds.CONSTRUCTED_POP, "Constructed",
-      "Breeds by external process, where individuals "
-          + " are \"constructed\" in some way.");
-  /**
-   * Race can gain sustenance from radiation.
-   * This does NOT mean that it able to *produce* food,
-   * but rather that it can *sustain itself* with radiation.
-   */
-  public static final RaceTrait RADIOSYNTHESIS = new RaceTrait(
-      TraitIds.RADIOSYNTHESIS, "Radiosynthesis",
-      "Required sustenance (food) for population"
-          + " is reduced by 1 per existing population,"
-          + " up to planet's radiation value.");
-
   /** ID of the trait */
   private String traitId;
   /** Trait name */

--- a/src/main/java/org/openRealmOfStars/player/race/trait/RaceTrait.java
+++ b/src/main/java/org/openRealmOfStars/player/race/trait/RaceTrait.java
@@ -1,4 +1,4 @@
-package org.openRealmOfStars.player.race;
+package org.openRealmOfStars.player.race.trait;
 /*
  * Open Realm of Stars game project
  * Copyright (C) 2023 BottledByte
@@ -23,6 +23,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
+import org.openRealmOfStars.player.race.SpaceRace;
+
 /**
  * Represents a trait that SpaceRace may have.
  *
@@ -45,13 +47,14 @@ import java.util.Objects;
  */
 public final class RaceTrait {
   /** Robotic */
-  public static final RaceTrait ROBOTIC = new RaceTrait("ROBOTIC", "Robotic",
+  public static final RaceTrait ROBOTIC = new RaceTrait(TraitIds.ROBOTIC,
+      "Robotic",
       "Race is robotic.");
   /**
    * Eats minerals.
    * Cannot be combined with ENERGY_POWERED.
    */
-  public static final RaceTrait LITHOVORIC = new RaceTrait("LITHOVORIC",
+  public static final RaceTrait LITHOVORIC = new RaceTrait(TraitIds.LITHOVORIC,
       "Lithovoric",
       "Eats minerals instead of food.", "ENERGY_POWERED");
   /**
@@ -59,17 +62,17 @@ public final class RaceTrait {
    * Cannot be combined with LITHOVORIC.
    */
   public static final RaceTrait ENERGY_POWERED = new RaceTrait(
-      "ENERGY_POWERED", "Powered",
+      TraitIds.ENERGY_POWERED, "Powered",
       "Consumes energy credits instead of food"
           + " at a rate of 1 credit per 4 population.");
   /** Concept of parental heritage is not applicable for the race. */
   public static final RaceTrait NO_HEIRS = new RaceTrait(
-      "NO_HEIRS", "No heirs",
+      TraitIds.NO_HEIRS, "No heirs",
       "Race has unusual birth process, to which it is"
           + " not possible to apply concept of parental heritage.");
   /** Race can breed by explictly constructing it's own population. */
   public static final RaceTrait CONSTRUCTED_POP = new RaceTrait(
-      "CONSTRUCTED_POP", "Constructed",
+      TraitIds.CONSTRUCTED_POP, "Constructed",
       "Breeds by external process, where individuals "
           + " are \"constructed\" in some way.");
   /**
@@ -78,7 +81,7 @@ public final class RaceTrait {
    * but rather that it can *sustain itself* with radiation.
    */
   public static final RaceTrait RADIOSYNTHESIS = new RaceTrait(
-      "RADIOSYNTHESIS", "Radiosynthesis",
+      TraitIds.RADIOSYNTHESIS, "Radiosynthesis",
       "Required sustenance (food) for population"
           + " is reduced by 1 per existing population,"
           + " up to planet's radiation value.");

--- a/src/main/java/org/openRealmOfStars/player/race/trait/RaceTrait.java
+++ b/src/main/java/org/openRealmOfStars/player/race/trait/RaceTrait.java
@@ -19,6 +19,7 @@ package org.openRealmOfStars.player.race.trait;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -102,12 +103,24 @@ public final class RaceTrait {
    * @param description description of the trait, must be non-null
    * @param conflictsWith Array of IDs of traits this trait conflicts with
    */
-  private RaceTrait(final String id, final String name,
+  RaceTrait(final String id, final String name,
       final String description, final String... conflictsWith) {
+    this(id, name, description, Arrays.asList(conflictsWith));
+  }
+
+  /**
+   * Creates new RaceTrait
+   * @param id ID of the trait, must be unique and non-null
+   * @param name name of the trait, must be non-null
+   * @param description description of the trait, must be non-null
+   * @param conflictsWith Collection of IDs of traits this trait conflicts with
+   */
+  RaceTrait(final String id, final String name,
+      final String description, final Collection<String> conflictsWith) {
     this.traitId = Objects.requireNonNull(id);
     this.traitName = Objects.requireNonNull(name);
     this.description = Objects.requireNonNull(description);
-    this.conflictsWithIds = new ArrayList<>(Arrays.asList(conflictsWith));
+    this.conflictsWithIds = new ArrayList<>(conflictsWith);
   }
 
   /**

--- a/src/main/java/org/openRealmOfStars/player/race/trait/TraitFactory.java
+++ b/src/main/java/org/openRealmOfStars/player/race/trait/TraitFactory.java
@@ -1,0 +1,162 @@
+package org.openRealmOfStars.player.race.trait;
+/*
+ * Open Realm of Stars game project
+ * Copyright (C) 2023 BottledByte
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see http://www.gnu.org/licenses/
+ */
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Optional;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.openRealmOfStars.utilities.DataLoader;
+import org.openRealmOfStars.utilities.ErrorLogger;
+
+/**
+ * Creates {@link RaceTrait}s, which it loaded from data files.
+ */
+public final class TraitFactory {
+  /** The Singleton */
+  private static final TraitFactory SINGLETON = new TraitFactory();
+
+  /**
+   * Create/Retrieve RaceTrait for given ID, if loaded
+   * @param traitId ID of trait to retrieve
+   * @return RaceTrait or empty
+   */
+  public static Optional<RaceTrait> create(final String traitId) {
+    return SINGLETON.createById(traitId);
+  }
+
+  /**
+   * Check if all hardcoded RaceTraits are available.
+   * @return True if all hardcoded RaceTraits are loaded
+   */
+  public static boolean hardcodedTraitsAvailable() {
+    return SINGLETON.hasHardcodedTraits();
+  }
+
+  /** RaceTraits this factory knows. IDs are used as keys. */
+  private HashMap<String, RaceTrait> raceTraits;
+  /** Tracks if factory is initialized with data */
+  private boolean initialized;
+  /** JSON data loader */
+  private DataLoader<String, RaceTrait> loader;
+
+  /** Contructor */
+  private TraitFactory() {
+    this.raceTraits = new HashMap<>();
+    this.initialized = false;
+    this.loader = new RaceTraitLoader();
+  }
+
+  /**
+   * Create/Retrieve RaceTrait for given ID, initialize factory if not yet
+   * @param traitId ID of trait to retrieve
+   * @return RaceTrait or empty
+   */
+  private Optional<RaceTrait> createById(final String traitId) {
+    if (!initialized) {
+      initialized = true;
+      init();
+    }
+
+    final var cachedTrait = raceTraits.get(traitId);
+    return Optional.ofNullable(cachedTrait);
+  }
+
+  /**
+   * Check if all hardcoded RaceTraits are available.
+   * @return True if all hardcoded RaceTraits are loaded
+   */
+  private boolean hasHardcodedTraits() {
+    for (var traitId : TraitIds.getHardcodedIds()) {
+      final var traitOpt = createById(traitId);
+      if (traitOpt.isEmpty()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** (Re)Initialize the factory */
+  private void init() {
+    raceTraits.clear();
+    final var basePath = "resources/data/traits/";
+    final String[] files = {
+        "base" };
+    final var traitsLoaded = loader.loadAll(raceTraits, basePath, files);
+    ErrorLogger.log("RaceTraits loaded: " + traitsLoaded);
+    if (!hasHardcodedTraits()) {
+      ErrorLogger.log("Some core RaceTraits were not loaded."
+          + " Game might not work as expected!");
+    }
+  }
+}
+
+/** RaceTrait loader */
+class RaceTraitLoader extends DataLoader<String, RaceTrait> {
+
+  /**
+   * Parse RaceTrait from a JSON file.
+   * <p>
+   * JSON RaceTrait object must have following format:<ul>
+   * <li>id : String</li>
+   * <li>name : String</li>
+   * <li>description: String</li>
+   * <li>conflictsWith : List of Strings (OPTIONAL)</li>
+   * </ul>
+   * </p>
+   * JSON RaceTraits missing the "conflicsWith" field
+   * are considered to have no conflicts.
+   * @param jobj JSONObject to parse RaceTrait from
+   * @return Parsed RaceTrait or empty
+   */
+  @Override
+  protected Optional<RaceTrait> parseFromJson(final JSONObject jobj) {
+    try {
+      final var traitId = jobj.getString("id");
+      final var name = jobj.getString("name");
+      final var description = jobj.getString("description");
+
+      var jsonConflictingIds = jobj.optJSONArray("conflictsWith",
+          new JSONArray());
+      var conflictingIds = new ArrayList<String>();
+      for (int i = 0; i < jsonConflictingIds.length(); i++) {
+        conflictingIds.add(jsonConflictingIds.getString(i));
+      }
+
+      var tmpTrait = new RaceTrait(traitId, name, description, conflictingIds);
+      return Optional.of(tmpTrait);
+    } catch (JSONException e) {
+      ErrorLogger.log(e);
+    }
+
+    return Optional.empty();
+  }
+
+  @Override
+  protected String valueIdGetter(final RaceTrait value) {
+    return value.getId();
+  }
+
+  @Override
+  protected String typeNameGetter() {
+    return "RaceTrait";
+  }
+}

--- a/src/main/java/org/openRealmOfStars/player/race/trait/TraitIds.java
+++ b/src/main/java/org/openRealmOfStars/player/race/trait/TraitIds.java
@@ -1,0 +1,91 @@
+package org.openRealmOfStars.player.race.trait;
+/*
+ * Open Realm of Stars game project
+ * Copyright (C) 2023 BottledByte
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see http://www.gnu.org/licenses/
+ */
+
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Class holding constants with IDs of all {@link RaceTrait}s
+ * that are officially hardcoded in game code.
+ *
+ * <p>
+ * When RaceTrait dependency arises, ID of said RaceTrait
+ * should be immediately written here as a constant.
+ * There is a method that allows retrieval of all hardcoded trait IDs.
+ * This method can be used for sanity checks at data-loading, etc.
+ * </p>
+ *
+ * This class relies on Reflection for simple, error-free
+ * addition of new trait IDs and their easy use in code,
+ * while allowing listing of all hardcoded IDs.
+ * TODO: Use code generation instead, the reflection is not needed for this
+ */
+public final class TraitIds {
+  /** Robotic */
+  public static final String ROBOTIC = "ROBOTIC";
+  /**
+   * Eats minerals.
+   * Cannot be combined with ENERGY_POWERED.
+   */
+  public static final String LITHOVORIC = "LITHOVORIC";
+  /**
+   * Eats energy (credits).
+   * Cannot be combined with LITHOVORIC.
+   */
+  public static final String ENERGY_POWERED = "ENERGY_POWERED";
+  /** Concept of parental heritage is not applicable for the race. */
+  public static final String NO_HEIRS = "NO_HEIRS";
+  /** Race can breed by explictly constructing it's own population. */
+  public static final String CONSTRUCTED_POP = "CONSTRUCTED_POP";
+  /**
+   * Race can gain sustenance from radiation.
+   * This does NOT mean that it able to *produce* food,
+   * but rather that it can *sustain itself* with radiation.
+   */
+  public static final String RADIOSYNTHESIS = "RADIOSYNTHESIS";
+
+  /** List storing all hardcoded IDs. Populated at runtime, via reflection. */
+  private static List<String> hardcodedIds = null;
+
+  /**
+   * Get List of all hardcoded IDs
+   * @return List of all hardcoded IDs
+   */
+  public static List<String> getHardcodedIds() {
+    if (hardcodedIds != null) {
+      return hardcodedIds;
+    }
+
+    // Use class reflection to get all public static
+    // fields of this class, then cache the result.
+    final var idList = Arrays.stream(TraitIds.class.getDeclaredFields())
+        .filter(field -> Modifier.isPublic(field.getModifiers()))
+        .filter(field -> Modifier.isStatic(field.getModifiers()))
+        .map(field -> field.getName())
+        .toList();
+    hardcodedIds = idList;
+    return idList;
+  }
+
+  /** Hidden constructor */
+  private TraitIds() {
+  }
+
+}

--- a/src/main/java/org/openRealmOfStars/player/race/trait/TraitIds.java
+++ b/src/main/java/org/openRealmOfStars/player/race/trait/TraitIds.java
@@ -20,6 +20,7 @@ package org.openRealmOfStars.player.race.trait;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Class holding constants with IDs of all {@link RaceTrait}s
@@ -79,7 +80,7 @@ public final class TraitIds {
         .filter(field -> Modifier.isPublic(field.getModifiers()))
         .filter(field -> Modifier.isStatic(field.getModifiers()))
         .map(field -> field.getName())
-        .toList();
+        .collect(Collectors.toList());
     hardcodedIds = idList;
     return idList;
   }

--- a/src/main/java/org/openRealmOfStars/starMap/planet/Planet.java
+++ b/src/main/java/org/openRealmOfStars/starMap/planet/Planet.java
@@ -39,9 +39,9 @@ import org.openRealmOfStars.player.leader.Perk;
 import org.openRealmOfStars.player.leader.stats.StatType;
 import org.openRealmOfStars.player.message.Message;
 import org.openRealmOfStars.player.message.MessageType;
-import org.openRealmOfStars.player.race.RaceTrait;
 import org.openRealmOfStars.player.race.SpaceRace;
 import org.openRealmOfStars.player.race.SpaceRaceUtility;
+import org.openRealmOfStars.player.race.trait.TraitIds;
 import org.openRealmOfStars.player.ship.Ship;
 import org.openRealmOfStars.player.ship.ShipHullType;
 import org.openRealmOfStars.player.ship.ShipSize;
@@ -869,11 +869,11 @@ public class Planet {
     // Energy-powered races have maintenance for every 4th of population
     var ownerInfo = planetOwnerInfo;
     if (ownerInfo != null
-        && ownerInfo.getRace().hasTrait(RaceTrait.ENERGY_POWERED.getId())) {
+        && ownerInfo.getRace().hasTrait(TraitIds.ENERGY_POWERED)) {
       // If race can sustain itself from radiation,
       // adjust the amount of maintained population accordingly
       var popToMaintain = getTotalPopulation();
-      if (ownerInfo.getRace().hasTrait(RaceTrait.RADIOSYNTHESIS.getId())) {
+      if (ownerInfo.getRace().hasTrait(TraitIds.RADIOSYNTHESIS)) {
         int sustFromRad = Math.min(getRadiationLevel(), popToMaintain);
         popToMaintain -= sustFromRad;
       }
@@ -1553,7 +1553,7 @@ public class Planet {
 
     // TODO: "Self-sustenance" radiosynthesis should not "produce" food
     // It does in order to not break population growing
-    if (planetRace.hasTrait(RaceTrait.RADIOSYNTHESIS.getId())) {
+    if (planetRace.hasTrait(TraitIds.RADIOSYNTHESIS)) {
       final int rad = getRadiationLevel();
       final int currentPop = getTotalPopulation();
       final int sustFromRad = Math.min(rad, currentPop);
@@ -1794,7 +1794,7 @@ public class Planet {
       SpaceRace planetRace = planetOwnerInfo.getRace();
       // Population can construct itself
       // Lookup valid construction project for race based on singular name
-      if (planetRace.hasTrait(RaceTrait.CONSTRUCTED_POP.getId())
+      if (planetRace.hasTrait(TraitIds.CONSTRUCTED_POP)
           && getTotalPopulation() < getPopulationLimit()) {
         var popProjectId = planetRace.getNameSingle() + " citizen";
         var popProject = ConstructionFactory.createByName(popProjectId);

--- a/src/main/resources/resources/data/traits/base.json
+++ b/src/main/resources/resources/data/traits/base.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "ROBOTIC",
+    "name": "Robotic",
+    "description": "Race is robotic."
+  },
+  {
+    "id": "LITHOVORIC",
+    "name": "Lithovoric",
+    "description": "Eats minerals instead of food.",
+    "conflictsWith": [
+      "ENERGY_POWERED"
+    ]
+  },
+  {
+    "id": "ENERGY_POWERED",
+    "name": "Powered",
+    "description": "Consumes energy credits instead of food at a rate of 1 credit per 4 population.",
+    "conflictsWith": [
+      "LITHOVORIC"
+    ]
+  },
+  {
+    "id": "NO_HEIRS",
+    "name": "No heirs",
+    "description": "Race has unusual birth process, to which it is not possible to apply concept of parental heritage."
+  },
+  {
+    "id": "CONSTRUCTED_POP",
+    "name": "Constructed",
+    "description": "Breeds by external process, where individuals are \"constructed\" in some way."
+  },
+  {
+    "id": "RADIOSYNTHESIS",
+    "name": "Radiosynthesis",
+    "description": "Required sustenance (food) for population is reduced by 1 per existing population up to planet's radiation value."
+  }
+]

--- a/src/test/java/org/openRealmOfStars/ai/planet/PlanetHandlingTest.java
+++ b/src/test/java/org/openRealmOfStars/ai/planet/PlanetHandlingTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
@@ -58,11 +59,20 @@ import org.openRealmOfStars.starMap.planet.construction.BuildingFactory;
 import org.openRealmOfStars.starMap.planet.construction.BuildingType;
 import org.openRealmOfStars.starMap.planet.construction.Construction;
 
+import junit.framework.TestCase;
+
 /**
  * Test for PlanetHandling class
  */
 
-public class PlanetHandlingTest {
+public class PlanetHandlingTest extends TestCase {
+
+  /** TODO: Remove when SpaceRaces are dehardcoded */
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    SpaceRace.initialize();
+  }
 
   /**
    * Create basic farm with mockito


### PR DESCRIPTION
Final step for GH-673, while taking GH-666 into account.

Trait definitions are loaded from `resources/data/traits/base.json`.

Breaks some test, because of `SpaceRace` enum. I ignored it, as those tests should be removed anyway.