### PR TITLE
Add Mercantile RaceTrait

### DIFF
--- a/src/main/java/org/openRealmOfStars/player/fleet/TradeRoute.java
+++ b/src/main/java/org/openRealmOfStars/player/fleet/TradeRoute.java
@@ -18,7 +18,7 @@ package org.openRealmOfStars.player.fleet;
  */
 
 import org.openRealmOfStars.player.PlayerInfo;
-import org.openRealmOfStars.player.race.SpaceRace;
+import org.openRealmOfStars.player.race.trait.TraitIds;
 import org.openRealmOfStars.starMap.planet.Planet;
 
 /**
@@ -59,6 +59,8 @@ public class TradeRoute {
     this.tradeWorld = tradeWorld;
     this.trader = trader;
     tradeValue = 0;
+    final var traderRace = this.trader.getRace();
+    final var traderGovernment = this.trader.getGovernment();
     double dist = fleet.getCoordinate().calculateDistance(
         this.originWorld.getCoordinate());
     if (dist <= 1) {
@@ -66,8 +68,8 @@ public class TradeRoute {
       if (tradeValue > 1) {
         tradeValue = tradeValue / 2;
       }
-      tradeValue = tradeValue + this.trader.getGovernment().getTradeBonus();
-      if (tradeValue > 0 && this.trader.getRace() == SpaceRace.SCAURIANS) {
+      tradeValue = tradeValue + traderGovernment.getTradeBonus();
+      if (tradeValue > 0 && traderRace.hasTrait(TraitIds.MERCANTILE)) {
         tradeValue = tradeValue * 3 / 2;
       }
     } else {
@@ -78,8 +80,8 @@ public class TradeRoute {
         if (tradeValue > 1) {
           tradeValue = tradeValue / 2;
         }
-        tradeValue = tradeValue + this.trader.getGovernment().getTradeBonus();
-        if (tradeValue > 0 && this.trader.getRace() == SpaceRace.SCAURIANS) {
+        tradeValue = tradeValue + traderGovernment.getTradeBonus();
+        if (tradeValue > 0 && traderRace.hasTrait(TraitIds.MERCANTILE)) {
           tradeValue = tradeValue * 3 / 2;
         }
       }
@@ -126,6 +128,7 @@ public class TradeRoute {
     }
     return sb.toString();
   }
+
   /**
    * Get the origin world where fleet will start.
    * @return Origin world

--- a/src/main/java/org/openRealmOfStars/player/race/SpaceRace.java
+++ b/src/main/java/org/openRealmOfStars/player/race/SpaceRace.java
@@ -220,6 +220,9 @@ public enum SpaceRace {
     TraitFactory.create(TraitIds.RADIOSYNTHESIS).ifPresent(trait -> {
       CHIRALOIDS.addTrait(trait);
     });
+    TraitFactory.create(TraitIds.MERCANTILE).ifPresent(trait -> {
+      SCAURIANS.addTrait(trait);
+    });
   }
 
   /**

--- a/src/main/java/org/openRealmOfStars/player/race/trait/TraitIds.java
+++ b/src/main/java/org/openRealmOfStars/player/race/trait/TraitIds.java
@@ -61,6 +61,8 @@ public final class TraitIds {
    * but rather that it can *sustain itself* with radiation.
    */
   public static final String RADIOSYNTHESIS = "RADIOSYNTHESIS";
+  /** Gets +1 credit for each "trade" building and +50% from ship trading */
+  public static final String MERCANTILE = "MERCANTILE";
 
   /** List storing all hardcoded IDs. Populated at runtime, via reflection. */
   private static List<String> hardcodedIds = null;

--- a/src/main/java/org/openRealmOfStars/starMap/StarMapUtilities.java
+++ b/src/main/java/org/openRealmOfStars/starMap/StarMapUtilities.java
@@ -30,6 +30,7 @@ import org.openRealmOfStars.player.leader.Perk;
 import org.openRealmOfStars.player.message.Message;
 import org.openRealmOfStars.player.message.MessageType;
 import org.openRealmOfStars.player.race.SpaceRace;
+import org.openRealmOfStars.player.race.trait.TraitIds;
 import org.openRealmOfStars.player.ship.Ship;
 import org.openRealmOfStars.player.ship.ShipStat;
 import org.openRealmOfStars.player.tech.TechFactory;
@@ -763,7 +764,7 @@ public final class StarMapUtilities {
         credits++;
       }
       if (credits > 0) {
-        if (info.getRace() == SpaceRace.SCAURIANS) {
+        if (info.getRace().hasTrait(TraitIds.MERCANTILE)) {
           credits = credits * 3 / 2;
         }
         info.setTotalCredits(info.getTotalCredits() + credits);
@@ -806,7 +807,7 @@ public final class StarMapUtilities {
         credits++;
       }
       if (credits > 0) {
-        if (info.getRace() == SpaceRace.SCAURIANS) {
+        if (info.getRace().hasTrait(TraitIds.MERCANTILE)) {
           credits = credits * 3 / 2;
         }
         if (fleet.getCommander() != null) {

--- a/src/main/java/org/openRealmOfStars/starMap/planet/Planet.java
+++ b/src/main/java/org/openRealmOfStars/starMap/planet/Planet.java
@@ -835,11 +835,11 @@ public class Planet {
     case PRODUCTION_CREDITS: {
       for (Building build : getBuildingList()) {
         result = result + build.getCredBonus();
-        if (planetOwnerInfo.getRace() == SpaceRace.SCAURIANS
+        // Special ability for mercantile races to get
+        // one extra credit per trade building
+        if (planetOwnerInfo.getRace().hasTrait(TraitIds.MERCANTILE)
             && build.getCredBonus() > 0) {
-          // Special ability for scaurians to get one extra credit
-          // per trade building
-          result++;
+          result += 1;
         }
       }
       break;

--- a/src/main/java/org/openRealmOfStars/starMap/planet/construction/Building.java
+++ b/src/main/java/org/openRealmOfStars/starMap/planet/construction/Building.java
@@ -18,6 +18,7 @@ package org.openRealmOfStars.starMap.planet.construction;
  */
 
 import org.openRealmOfStars.player.race.SpaceRace;
+import org.openRealmOfStars.player.race.trait.TraitIds;
 import org.openRealmOfStars.utilities.IOUtilities;
 
 /**
@@ -308,8 +309,8 @@ public class Building extends Construction {
       }
       sb.append("Cred.: +");
       int value = getCredBonus();
-      if (race != null && race == SpaceRace.SCAURIANS) {
-        value = value + 1;
+      if (race != null && race.hasTrait(TraitIds.MERCANTILE)) {
+        value += 1;
       }
       sb.append(value);
       space = true;

--- a/src/main/resources/resources/data/traits/base.json
+++ b/src/main/resources/resources/data/traits/base.json
@@ -34,5 +34,10 @@
     "id": "RADIOSYNTHESIS",
     "name": "Radiosynthesis",
     "description": "Required sustenance (food) for population is reduced by 1 per existing population up to planet's radiation value."
+  },
+  {
+    "id": "MERCANTILE",
+    "name": "Mercantile",
+    "description": "Receives +1 additional credit from each credit-producing building and 50% more from trade routes."
   }
 ]

--- a/src/test/java/org/openRealmOfStars/ai/mission/MissionHandlingTest.java
+++ b/src/test/java/org/openRealmOfStars/ai/mission/MissionHandlingTest.java
@@ -267,6 +267,7 @@ public class MissionHandlingTest {
     Mockito.when(diplomacy.getDiplomacyList(Mockito.anyInt())).thenReturn(diplomacyList);
     Mockito.when(diplomacy.getDiplomaticRelation(0)).thenReturn(Diplomacy.TRADE_ALLIANCE);
     PlayerInfo info = Mockito.mock(PlayerInfo.class);
+    Mockito.when(info.getRace()).thenReturn(SpaceRace.HUMAN);
     Mockito.when(info.getDiplomacy()).thenReturn(diplomacy);
     Mockito.when(info.getMsgList()).thenReturn(msgList);
     Mockito.when(info.getGovernment()).thenReturn(GovernmentType.AI);

--- a/src/test/java/org/openRealmOfStars/ai/planet/PlanetHandlingTest.java
+++ b/src/test/java/org/openRealmOfStars/ai/planet/PlanetHandlingTest.java
@@ -17,11 +17,8 @@ package org.openRealmOfStars.ai.planet;
  * along with this program; if not, see http://www.gnu.org/licenses/
  */
 
-import static org.junit.Assert.assertEquals;
-
 import java.util.ArrayList;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;

--- a/src/test/java/org/openRealmOfStars/player/fleet/TradeRouteTest.java
+++ b/src/test/java/org/openRealmOfStars/player/fleet/TradeRouteTest.java
@@ -17,8 +17,6 @@ package org.openRealmOfStars.player.fleet;
  * along with this program; if not, see http://www.gnu.org/licenses/
  */
 
-import static org.junit.Assert.*;
-
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
@@ -28,11 +26,20 @@ import org.openRealmOfStars.player.race.SpaceRace;
 import org.openRealmOfStars.starMap.Coordinate;
 import org.openRealmOfStars.starMap.planet.Planet;
 
+import junit.framework.TestCase;
+
 /**
 * Trade route calculation for fleet
 *
 */
-public class TradeRouteTest {
+public class TradeRouteTest extends TestCase {
+
+  /** TODO: Remove when SpaceRaces are dehardcoded */
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    SpaceRace.initialize();
+  }
 
   @Test
   @Category(org.openRealmOfStars.UnitTest.class)


### PR DESCRIPTION
Add trait that gives +1 credit for each credit-producing building and 50% bonus credits from trading with fleets.
See GH-673
 
And cleanup and adjust some tests.

**This is 7th time where the Unit tests created a completely imaginary bug** I wasted 15 minutes of my life fixing. :tada: Total time wasted on false-positive tests in this project crossed the 5 hours boundary in my case.

*So, from now on, I will either ignore the unit tests completely. Or simply stop contributing, until situation with defective tests improve. Because this is really absurd.*

IMHO, this can be fixed only by *deleting almost all behavioral and unit tests*. It is almost impossible to predict which of them contain critical flaws like violating game's internal contracts. By those contract violations, I mean that the excessive mocking typically results in `null` where can never, ever, be `null` in real game (typically there is a default value in real game). Such cases are extremely confusing, as they just deny all game-code logic.

Only tests that I consider OK are the "integration" tests (where AI-only game is simulated).
They are the only ones which actually caught some real bugs for me :neutral_face: 

And as always:
less tests == less code == less work == more productivity