### PR TITLE
Fix and cleanup RaceTrait-related code

### DIFF
--- a/src/main/java/org/openRealmOfStars/player/race/SpaceRace.java
+++ b/src/main/java/org/openRealmOfStars/player/race/SpaceRace.java
@@ -241,6 +241,9 @@ public enum SpaceRace {
       REBORGIANS.addTrait(trait);
       LITHORIANS.addTrait(trait);
     });
+    TraitFactory.create(TraitIds.FIXED_GROWTH).ifPresent(trait -> {
+      REBORGIANS.addTrait(trait);
+    });
     TraitFactory.create(TraitIds.CREDIT_RUSH).ifPresent(trait -> {
       HUMAN.addTrait(trait);
       SPORKS.addTrait(trait);
@@ -790,7 +793,7 @@ public enum SpaceRace {
    */
   public int getFoodSpeed() {
     int result = 100;
-    if (hasTrait(TraitIds.ENERGY_POWERED) || hasTrait(TraitIds.LITHOVORIC)) {
+    if (!isEatingFood()) {
       result = 0;
     }
     if (hasTrait(TraitIds.FAST_FOOD_PROD)) {
@@ -899,10 +902,7 @@ public enum SpaceRace {
    */
   public int getFoodRequire() {
     int result = 100;
-    if (hasTrait(TraitIds.ENERGY_POWERED)) {
-      result = 0;
-    }
-    if (hasTrait(TraitIds.LITHOVORIC)) {
+    if (!isEatingFood()) {
       result = 0;
     }
     if (hasTrait(TraitIds.EAT_LESS)) {
@@ -1007,17 +1007,6 @@ public enum SpaceRace {
   }
 
   /**
-   * Get racial hull point if available
-   * @return normal 0 or 1
-   */
-  public int getExtraHullPoint() {
-    if (hasTrait(TraitIds.MASSIVE_SIZE)) {
-      return 1;
-    }
-    return 0;
-  }
-
-  /**
    * Get how many star years to update defense
    * @return int
    */
@@ -1104,97 +1093,6 @@ public enum SpaceRace {
       return 55;
     default:
       return 50;
-    }
-  }
-
-  /**
-   * What is the minimum number of attack ships
-   * @return int
-   */
-  public int getAIMinimumAttackShips() {
-    switch (this) {
-    case HUMAN:
-    case SPACE_PIRATE:
-    case SPACE_MONSTERS:
-      return 3;
-    case MECHIONS:
-      return 3;
-    case SPORKS:
-      return 4;
-    case GREYANS:
-      return 3;
-    case CENTAURS:
-      return 2;
-    case MOTHOIDS:
-      return 3;
-    case TEUTHIDAES:
-      return 3;
-    case SCAURIANS:
-      return 3;
-    case HOMARIANS:
-      return 3;
-    case CHIRALOIDS:
-      return 4;
-    case REBORGIANS:
-      return 4;
-    case LITHORIANS:
-      return 3;
-    case ALTEIRIANS:
-      return 3;
-    case SMAUGIRIANS:
-      return 3;
-    case SYNTHDROIDS:
-      return 3;
-    case ALONIANS:
-      return 3;
-    default:
-      return 3;
-    }
-  }
-
-  /**
-   * What is the minimum number of conquer ships aka bomber and
-   * troopers
-   * @return int
-   */
-  public int getAIMinimumConquerShips() {
-    switch (this) {
-    case HUMAN:
-    case SPACE_PIRATE:
-    case SPACE_MONSTERS:
-      return 1;
-    case MECHIONS:
-      return 1;
-    case SPORKS:
-      return 2;
-    case GREYANS:
-      return 1;
-    case CENTAURS:
-      return 1;
-    case MOTHOIDS:
-      return 2;
-    case TEUTHIDAES:
-      return 2;
-    case SCAURIANS:
-      return 1;
-    case HOMARIANS:
-      return 1;
-    case CHIRALOIDS:
-      return 1;
-    case REBORGIANS:
-      return 2;
-    case LITHORIANS:
-      return 1;
-    case ALTEIRIANS:
-      return 2;
-    case SMAUGIRIANS:
-      return 1;
-    case SYNTHDROIDS:
-      return 1;
-    case ALONIANS:
-      return 1;
-    default:
-      return 1;
     }
   }
 
@@ -1314,22 +1212,22 @@ public enum SpaceRace {
   public int getLifeSpan() {
     int result = 80;
     if (hasTrait(TraitIds.SHORT_LIFE_SPAN)) {
-      result = result - 10;
+      result -= 10;
     }
     if (hasTrait(TraitIds.LONG_LIFE_SPAN)) {
-      result = result + 10;
+      result += 10;
     }
     if (hasTrait(TraitIds.VERY_LONG_LIFE_SPAN)) {
-      result = result + 20;
+      result += 20;
     }
     if (hasTrait(TraitIds.SLOW_METABOLISM)) {
-      result = result + 10;
+      result += 10;
     }
     if (hasTrait(TraitIds.CYBORG_LIFE_SPAN)) {
-      result = result + 70;
+      result += 70;
     }
     if (hasTrait(TraitIds.MASSIVE_SIZE)) {
-      result = result + 20;
+      result += 20;
     }
     if (hasTrait(TraitIds.ROBOTIC)) {
       result = 2000;

--- a/src/main/java/org/openRealmOfStars/player/race/trait/TraitIds.java
+++ b/src/main/java/org/openRealmOfStars/player/race/trait/TraitIds.java
@@ -64,26 +64,19 @@ public final class TraitIds {
   public static final String RADIOSYNTHESIS = "RADIOSYNTHESIS";
   /** Gets +1 credit for each "trade" building and +50% from ship trading */
   public static final String MERCANTILE = "MERCANTILE";
-
   /** All ship design have 10% cloaking device built it. */
   public static final String BUILT_IN_CLOAKING_DEVICE =
       "BUILT_IN_CLOAKING_DEVICE";
-
   /** Require 50% less food to survive. */
   public static final String EAT_LESS = "EAT_LESS";
-
   /** Fast population growth. */
   public static final String FAST_GROWTH = "FAST_GROWTH";
-
   /** Slow population growth. */
   public static final String SLOW_GROWTH = "SLOW_GROWTH";
-
   /** Fixed population growth. */
   public static final String FIXED_GROWTH = "FIXED_GROWTH";
-
   /** Limited population growth. */
   public static final String LIMITED_GROWTH = "LIMITED_GROWTH";
-
   /** Credit Rush for projects */
   public static final String CREDIT_RUSH = "CREDIT_RUSH";
   /** Population Rush for projects */

--- a/src/main/java/org/openRealmOfStars/player/ship/ShipHull.java
+++ b/src/main/java/org/openRealmOfStars/player/ship/ShipHull.java
@@ -20,6 +20,7 @@ package org.openRealmOfStars.player.ship;
 import java.awt.image.BufferedImage;
 
 import org.openRealmOfStars.player.race.SpaceRace;
+import org.openRealmOfStars.player.race.trait.TraitIds;
 import org.openRealmOfStars.utilities.IOUtilities;
 
 /**
@@ -142,9 +143,9 @@ public class ShipHull {
     this.imageIndex = ShipImage.SCOUT;
     // Default for fleet capacity.
     this.fleetCapacity = 0.1;
-    // Centaur ships have extra hull point per slot
+    // Ships of physically large races have extra hull point per slot
     // but hulls are more expensive.
-    if (race == SpaceRace.CENTAURS) {
+    if (race.hasTrait(TraitIds.MASSIVE_SIZE)) {
       this.slotHull = this.slotHull + 1;
       this.metalCost = this.metalCost * 2;
       this.cost = this.cost * 3 / 2;

--- a/src/main/java/org/openRealmOfStars/starMap/planet/Planet.java
+++ b/src/main/java/org/openRealmOfStars/starMap/planet/Planet.java
@@ -2127,12 +2127,13 @@ public class Planet {
         }
       } else {
         food = calculateSurPlusFood();
-        if (planetOwnerInfo.getRace() == SpaceRace.REBORGIANS && food > 0) {
+        if (planetOwnerInfo.getRace().hasTrait(TraitIds.FIXED_GROWTH)
+            && food > 0) {
           food = 1;
         }
       }
       int require = 10;
-      if (planetOwnerInfo.getRace() == SpaceRace.SYNTHDROIDS) {
+      if (planetOwnerInfo.getRace().getGrowthSpeed() == 0) {
         if (food > 0) {
           food = 0;
         }

--- a/src/main/resources/resources/data/traits/base.json
+++ b/src/main/resources/resources/data/traits/base.json
@@ -141,7 +141,7 @@
   },
   {
     "id": "SHORT_LIFE_SPAN",
-    "name": "Short life spane",
+    "name": "Short life span",
     "description": "Short life span for leaders. Leaders live about 10 star years below average.",
     "conflictsWith": [
       "LONG_LIFE_SPAN", "VERY_LONG_LIFE_SPAN", "CYBORG_LIFE_SPAN"
@@ -149,7 +149,7 @@
   },
   {
     "id": "LONG_LIFE_SPAN",
-    "name": "Long life spane",
+    "name": "Long life span",
     "description": "Long life span for leaders. Leaders live about 10 star years longer than average.",
     "conflictsWith": [
       "LONG_LIFE_SPAN", "VERY_LONG_LIFE_SPAN", "CYBORG_LIFE_SPAN"
@@ -157,7 +157,7 @@
   },
   {
     "id": "VERY_LONG_LIFE_SPAN",
-    "name": "Very long life spane",
+    "name": "Very long life span",
     "description": "Very long life span for leaders. Leaders live about 20 star years longer than average.",
     "conflictsWith": [
       "LONG_LIFE_SPAN", "SHORT_LIFE_SPAN", "CYBORG_LIFE_SPAN"


### PR DESCRIPTION
Reuse defined, meaningful methods instead of ad-hoc `if`s :neutral_face: .
Add previously defined and unused RaceTrait to Reborgians.
Make code more generic.
Fix typos in RaceTrait names.

Also remove dead code in `SpaceRace`. Mostly AI behavior code, but AI code does not even belong to SpaceRace.