### PR TITLE
Add diplomacy RaceTraits, tweak "ship cloaking" trait

### DIFF
--- a/src/main/java/org/openRealmOfStars/player/race/SpaceRace.java
+++ b/src/main/java/org/openRealmOfStars/player/race/SpaceRace.java
@@ -216,7 +216,7 @@ public enum SpaceRace {
     TraitFactory.create(TraitIds.MERCANTILE).ifPresent(trait -> {
       SCAURIANS.addTrait(trait);
     });
-    TraitFactory.create(TraitIds.BUILT_IN_CLOAKING_DEVICE).ifPresent(trait -> {
+    TraitFactory.create(TraitIds.STEALTHY).ifPresent(trait -> {
       TEUTHIDAES.addTrait(trait);
     });
     TraitFactory.create(TraitIds.EAT_LESS).ifPresent(trait -> {

--- a/src/main/java/org/openRealmOfStars/player/race/trait/TraitIds.java
+++ b/src/main/java/org/openRealmOfStars/player/race/trait/TraitIds.java
@@ -65,8 +65,7 @@ public final class TraitIds {
   /** Gets +1 credit for each "trade" building and +50% from ship trading */
   public static final String MERCANTILE = "MERCANTILE";
   /** All ship design have 10% cloaking device built it. */
-  public static final String BUILT_IN_CLOAKING_DEVICE =
-      "BUILT_IN_CLOAKING_DEVICE";
+  public static final String STEALTHY = "STEALTHY";
   /** Require 50% less food to survive. */
   public static final String EAT_LESS = "EAT_LESS";
   /** Fast population growth. */

--- a/src/main/java/org/openRealmOfStars/player/ship/Ship.java
+++ b/src/main/java/org/openRealmOfStars/player/ship/Ship.java
@@ -937,7 +937,7 @@ private int getRemainingEnergy(final int index) {
           cloak = comp.getCloaking();
       }
     }
-    if (hull.getRace().hasTrait(TraitIds.BUILT_IN_CLOAKING_DEVICE)) {
+    if (hull.getRace().hasTrait(TraitIds.STEALTHY)) {
       cloak = cloak + 10;
     }
     return cloak;

--- a/src/main/resources/resources/data/traits/base.json
+++ b/src/main/resources/resources/data/traits/base.json
@@ -52,10 +52,10 @@
     "points": 1
   },
   {
-    "id": "BUILT_IN_CLOAKING_DEVICE",
-    "name": "Built in cloaking device",
-    "description": "All ships have built-in cloaking device which give 10% cloak.",
-    "points": 1
+    "id": "STEALTHY",
+    "name": "Stealthy",
+    "description": "Natural aptitude towards stealthy movement and actions. Race's ships have 10% cloaking, sharing this trait with their constructors.",
+    "points": 2
   },
   {
     "id": "EAT_LESS",


### PR DESCRIPTION
See discussion in #673 .

Adds 3 traits affecting diplomacy (Good, Bad, Extremely Bad).
Changes "cloaking trait" to "Stealthy", to add flavor + explanation and keeping it more in line with how traits should be designed. Also increase it's value.