### PR TITLE
Remove project rushing from SpaceRace

### DIFF
--- a/src/main/java/org/openRealmOfStars/ai/planet/PlanetHandling.java
+++ b/src/main/java/org/openRealmOfStars/ai/planet/PlanetHandling.java
@@ -375,16 +375,8 @@ public final class PlanetHandling {
             planet.getUnderConstruction());
         int rushChange = 0;
         boolean creditRush = true;
-        boolean hasCreditRush = false;
-        boolean hasPopulationRush = false;
-        if (info.getRace().hasCreditRush()
-            || info.getGovernment().hasCreditRush()) {
-          hasCreditRush = true;
-        }
-        if (info.getRace().hasPopulationRush()
-            || info.getGovernment().hasPopulationRush()) {
-          hasPopulationRush = true;
-        }
+        boolean hasCreditRush = info.getGovernment().hasCreditRush();
+        boolean hasPopulationRush = info.getGovernment().hasPopulationRush();
         if (hasCreditRush
             && rushCost < info.getTotalCredits() && buildingTime > 1
             && rushCost > 0) {

--- a/src/main/java/org/openRealmOfStars/game/state/PlanetView.java
+++ b/src/main/java/org/openRealmOfStars/game/state/PlanetView.java
@@ -634,8 +634,7 @@ public class PlanetView extends BlackPanel {
     int rushCost = planet.getRushingCost(building);
     boolean rushingAvailable = false;
     if (rushCost > 0 && allowHandling && productionTime > 1) {
-      if ((info.getRace().hasCreditRush()
-          || info.getGovernment().hasCreditRush())
+      if (info.getGovernment().hasCreditRush()
           && rushCost <= info.getTotalCredits()
           && planet.getUnderConstruction() != null) {
         rushWithCreditsBtn.setEnabled(true);
@@ -646,8 +645,7 @@ public class PlanetView extends BlackPanel {
         rushWithCreditsBtn.setEnabled(false);
         rushWithCreditsBtn.setToolTipText(null);
       }
-      if ((info.getRace().hasPopulationRush()
-          || info.getGovernment().hasPopulationRush())
+      if (info.getGovernment().hasPopulationRush()
           && planet.getUnderConstruction() != null) {
         int populationCost = rushCost / Planet.POPULATION_RUSH_COST + 1;
         if (planet.getTotalPopulation() > populationCost) {

--- a/src/main/java/org/openRealmOfStars/player/race/SpaceRace.java
+++ b/src/main/java/org/openRealmOfStars/player/race/SpaceRace.java
@@ -237,25 +237,6 @@ public enum SpaceRace {
     TraitFactory.create(TraitIds.FIXED_GROWTH).ifPresent(trait -> {
       REBORGIANS.addTrait(trait);
     });
-    TraitFactory.create(TraitIds.CREDIT_RUSH).ifPresent(trait -> {
-      HUMAN.addTrait(trait);
-      SPORKS.addTrait(trait);
-      GREYANS.addTrait(trait);
-      CENTAURS.addTrait(trait);
-      TEUTHIDAES.addTrait(trait);
-      SCAURIANS.addTrait(trait);
-      ALTEIRIANS.addTrait(trait);
-      SMAUGIRIANS.addTrait(trait);
-      SPACE_PIRATE.addTrait(trait);
-      SPACE_MONSTERS.addTrait(trait);
-    });
-    TraitFactory.create(TraitIds.POPULATION_RUSH).ifPresent(trait -> {
-      MECHIONS.addTrait(trait);
-      SPORKS.addTrait(trait);
-      MOTHOIDS.addTrait(trait);
-      HOMARIANS.addTrait(trait);
-      REBORGIANS.addTrait(trait);
-    });
     TraitFactory.create(TraitIds.SLOW_CULTURE).ifPresent(trait -> {
       MECHIONS.addTrait(trait);
       HOMARIANS.addTrait(trait);
@@ -1096,20 +1077,6 @@ public enum SpaceRace {
       return MusicPlayer.MILLION_LIGHT_YEARS;
     }
   }
-  /**
-   * Has space race option to rush production with credits.
-   * @return True if credit rush is possible
-   */
-  public boolean hasCreditRush() {
-    return hasTrait(TraitIds.CREDIT_RUSH);
-  }
-  /**
-   * Has space race option to rush production with population.
-   * @return True if credit rush is possible
-   */
-  public boolean hasPopulationRush() {
-    return hasTrait(TraitIds.POPULATION_RUSH);
-  }
 
   /**
    * Is race eating organic food?
@@ -1534,22 +1501,6 @@ public enum SpaceRace {
   }
 
   /**
-   * Get rush option as a String
-   * @return String
-   */
-  private String getRushOption() {
-    if (hasCreditRush() && hasPopulationRush()) {
-      return "Credit and population";
-    }
-    if (hasCreditRush() && !hasPopulationRush()) {
-      return "Credit";
-    }
-    if (!hasCreditRush() && hasPopulationRush()) {
-      return "Population";
-    }
-    return "None";
-  }
-  /**
    * Get full description about the race, including the stats.
    * @param markDown if true then markDown is being used, otherwise HTML.
    * @param image Add image to wiki page if true
@@ -1668,10 +1619,6 @@ public enum SpaceRace {
     sb.append(dot);
     sb.append(" War resistance: ");
     sb.append(getWarFatigueResistance());
-    sb.append(lf);
-    sb.append(dot);
-    sb.append(" Rush: ");
-    sb.append(getRushOption());
     PlanetTypes planetTypes = PlanetTypes.getRandomStartPlanetType(this);
     int sustainable = getWorldTypeBaseValue(planetTypes.getWorldType());
     sb.append(lf);

--- a/src/main/java/org/openRealmOfStars/player/race/trait/TraitIds.java
+++ b/src/main/java/org/openRealmOfStars/player/race/trait/TraitIds.java
@@ -76,10 +76,6 @@ public final class TraitIds {
   public static final String FIXED_GROWTH = "FIXED_GROWTH";
   /** Limited population growth. */
   public static final String LIMITED_GROWTH = "LIMITED_GROWTH";
-  /** Credit Rush for projects */
-  public static final String CREDIT_RUSH = "CREDIT_RUSH";
-  /** Population Rush for projects */
-  public static final String POPULATION_RUSH = "POPULATION_RUSH";
   /** Slow culture speed for artists. */
   public static final String SLOW_CULTURE = "SLOW_CULTURE";
   /** Fast culture speed for artists. */

--- a/src/main/java/org/openRealmOfStars/starMap/planet/Planet.java
+++ b/src/main/java/org/openRealmOfStars/starMap/planet/Planet.java
@@ -452,16 +452,8 @@ public class Planet {
     if (prodReq < 0) {
       prodReq = 0;
     }
-    boolean hasCreditRush = false;
-    boolean hasPopulationRush = false;
-    if (info.getRace().hasCreditRush()
-        || info.getGovernment().hasCreditRush()) {
-      hasCreditRush = true;
-    }
-    if (info.getRace().hasPopulationRush()
-        || info.getGovernment().hasPopulationRush()) {
-      hasPopulationRush = true;
-    }
+    boolean hasCreditRush = info.getGovernment().hasCreditRush();
+    boolean hasPopulationRush = info.getGovernment().hasPopulationRush();
     int populationCost = rushCost / Planet.POPULATION_RUSH_COST + 1;
     if (rushCost > 0 && creditRush && hasCreditRush
         && rushCost <= info.getTotalCredits()) {

--- a/src/main/resources/resources/data/traits/base.json
+++ b/src/main/resources/resources/data/traits/base.json
@@ -103,18 +103,6 @@
     ]
   },
   {
-    "id": "CREDIT_RUSH",
-    "name": "Credit rush",
-    "description": "Rush projects by paying extra credits.",
-    "points": 0
-  },
-  {
-    "id": "POPULATION_RUSH",
-    "name": "Population rush",
-    "description": "Rush projects by sacrificing population.",
-    "points": 0
-  },
-  {
     "id": "SLOW_CULTURE",
     "name": "Slow culture",
     "description": "Slow culture speed from artist population.",


### PR DESCRIPTION
As per discussion in #673 .

Government is now only source of which rushing options are available.