### PR TITLE
Fix getRandomLivingRace method picking pseudo-races

### DIFF
--- a/src/main/java/org/openRealmOfStars/player/race/SpaceRace.java
+++ b/src/main/java/org/openRealmOfStars/player/race/SpaceRace.java
@@ -1748,6 +1748,9 @@ public enum SpaceRace {
   public static SpaceRace getRandomLivingRace() {
     var nonRoboticRaces = Stream.of(values())
         .filter(race -> !race.isRoboticRace())
+        // Filter out "pseudo-races"
+        .filter(
+            race -> race != SPACE_PIRATE && race != SpaceRace.SPACE_MONSTERS)
         .collect(Collectors.toList());
     if (nonRoboticRaces.isEmpty()) {
       return null;


### PR DESCRIPTION
Again, forgot about a code quirk :smile: 
There are races which are not races, which are now filtered out.

Removal of those pseudo-races (SPACE_PIRATE and SPACE_MONSTERS) should be a separate issue.
**Those two "races" break logical definition of what `SpaceRace` is.**