### PR TITLE
Add heir birth chance to Government

### DIFF
--- a/src/main/java/org/openRealmOfStars/game/state/AITurnView.java
+++ b/src/main/java/org/openRealmOfStars/game/state/AITurnView.java
@@ -3126,32 +3126,11 @@ public class AITurnView extends BlackPanel {
             }
           }
           int chance = 2;
-          if ((realm.getGovernment() == GovernmentType.CLAN
-               || realm.getGovernment() == GovernmentType.HORDE)
-              && heirs == 0) {
-            chance = 6;
+          if (heirs == 0) {
+            chance = realm.getGovernment().getHeirChance();
           }
-          if ((realm.getGovernment() == GovernmentType.CLAN
-              || realm.getGovernment() == GovernmentType.HORDE)
-             && heirs == 1) {
-           chance = 4;
-         }
-          if ((realm.getGovernment() == GovernmentType.EMPIRE
-              || realm.getGovernment() == GovernmentType.KINGDOM
-              || realm.getGovernment() == GovernmentType.NEST
-              || realm.getGovernment() == GovernmentType.FEUDALISM)
-              && heirs == 0) {
-            chance = 10;
-          }
-          if ((realm.getGovernment() == GovernmentType.EMPIRE
-              || realm.getGovernment() == GovernmentType.KINGDOM
-              || realm.getGovernment() == GovernmentType.FEUDALISM)
-              && heirs == 1) {
-            chance = 5;
-          }
-          if (realm.getGovernment() == GovernmentType.NEST
-              && heirs == 1) {
-            chance = 4;
+          if (heirs == 1) {
+            chance = realm.getGovernment().getHeirChance() / 2;
           }
           if (leader.getRace().hasTrait(TraitIds.NO_HEIRS)) {
             // Races without concept of parental heritage do not get heirs

--- a/src/main/java/org/openRealmOfStars/player/government/GovernmentType.java
+++ b/src/main/java/org/openRealmOfStars/player/government/GovernmentType.java
@@ -458,40 +458,33 @@ public enum GovernmentType {
   }
 
   /**
+   * Chance that heir will be born/found, 0 means no heirs.
+   * @return Chance for new heir, 0 if government does not have heirs.
+   */
+  public int getHeirChance() {
+    switch (this) {
+      case EMPIRE:
+      case KINGDOM:
+      case FEUDALISM: {
+        return 10;
+      }
+      case NEST:
+      case HORDE:
+      case CLAN: {
+        return 6;
+      }
+      default: {
+        return 0;
+      }
+    }
+  }
+
+  /**
    * Goverment can have heirs.
    * @return True or false
    */
   public boolean hasHeirs() {
-    switch (this) {
-      default:
-      case UNION:
-      case DEMOCRACY:
-      case FEDERATION:
-      case MECHANICAL_HORDE:
-      case AI:
-      case SPACE_PIRATES:
-      case HIVEMIND:
-      case GUILD:
-      case ENTERPRISE:
-      case HEGEMONY:
-      case HIERARCHY:
-      case REPUBLIC:
-      case COLLECTIVE:
-      case UTOPIA:
-      case TECHNOCRACY:
-      case SYNDICATE:
-      case REGIME: {
-        return false;
-      }
-      case NEST:
-      case EMPIRE:
-      case KINGDOM:
-      case HORDE:
-      case FEUDALISM:
-      case CLAN: {
-        return true;
-      }
-    }
+    return getHeirChance() > 0;
   }
 
   /**


### PR DESCRIPTION
Replace some hardcoded `if`s that "calculated" heir birth chance.
Also, it changes the formula for lowering chance with number of heirs but that can be adjusted in the future.
Now it is a formula, not "special case".