### PR TITLE
Add Strength and Productivity RaceTraits

### DIFF
--- a/src/main/java/org/openRealmOfStars/player/race/SpaceRace.java
+++ b/src/main/java/org/openRealmOfStars/player/race/SpaceRace.java
@@ -339,6 +339,13 @@ public enum SpaceRace {
       CHIRALOIDS.addTrait(trait);
       ALTEIRIANS.addTrait(trait);
     });
+    TraitFactory.create(TraitIds.HANDY).ifPresent(trait -> {
+      HOMARIANS.addTrait(trait);
+    });
+    TraitFactory.create(TraitIds.IMPRACTICAL).ifPresent(trait -> {
+      CHIRALOIDS.addTrait(trait);
+      ALTEIRIANS.addTrait(trait);
+    });
   }
 
   /**
@@ -695,42 +702,14 @@ public enum SpaceRace {
    * @return normal 100, half 50, double 200
    */
   public int getProductionSpeed() {
-    switch (this) {
-    case HUMAN:
-    case SPACE_PIRATE:
-    case SPACE_MONSTERS:
-      return 100;
-    case MECHIONS:
-      return 100;
-    case SPORKS:
-      return 100;
-    case GREYANS:
-      return 100;
-    case CENTAURS:
-      return 100;
-    case MOTHOIDS:
-      return 100;
-    case TEUTHIDAES:
-      return 100;
-    case SCAURIANS:
-      return 100;
-    case HOMARIANS:
-      return 150;
-    case CHIRALOIDS:
-      return 50;
-    case REBORGIANS:
-      return 100;
-    case LITHORIANS:
-      return 100;
-    case ALTEIRIANS:
-      return 50;
-    case SMAUGIRIANS:
-      return 100;
-    case SYNTHDROIDS:
-      return 100;
-    default:
-      return 0;
+    var result = 100;
+    if (hasTrait(TraitIds.HANDY)) {
+      result += 50;
     }
+    if (hasTrait(TraitIds.IMPRACTICAL)) {
+      result -= 50;
+    }
+    return result;
   }
 
   /**

--- a/src/main/java/org/openRealmOfStars/player/race/SpaceRace.java
+++ b/src/main/java/org/openRealmOfStars/player/race/SpaceRace.java
@@ -325,6 +325,20 @@ public enum SpaceRace {
     TraitFactory.create(TraitIds.DISGUSTING).ifPresent(trait -> {
       REBORGIANS.addTrait(trait);
     });
+    TraitFactory.create(TraitIds.STRONG).ifPresent(trait -> {
+      MECHIONS.addTrait(trait);
+      SPORKS.addTrait(trait);
+      CENTAURS.addTrait(trait);
+      HOMARIANS.addTrait(trait);
+      REBORGIANS.addTrait(trait);
+      LITHORIANS.addTrait(trait);
+    });
+    TraitFactory.create(TraitIds.WEAK).ifPresent(trait -> {
+      GREYANS.addTrait(trait);
+      MOTHOIDS.addTrait(trait);
+      CHIRALOIDS.addTrait(trait);
+      ALTEIRIANS.addTrait(trait);
+    });
   }
 
   /**
@@ -627,42 +641,17 @@ public enum SpaceRace {
    * @return normal 100, half 50, double 200
    */
   public int getMiningSpeed() {
-    switch (this) {
-    case HUMAN:
-    case SPACE_PIRATE:
-    case SPACE_MONSTERS:
-      return 100;
-    case MECHIONS:
-      return 150;
-    case SPORKS:
-      return 100;
-    case GREYANS:
-      return 100;
-    case CENTAURS:
-      return 100;
-    case MOTHOIDS:
-      return 50;
-    case TEUTHIDAES:
-      return 100;
-    case SCAURIANS:
-      return 50;
-    case HOMARIANS:
-      return 150;
-    case CHIRALOIDS:
-      return 100;
-    case REBORGIANS:
-      return 100;
-    case LITHORIANS:
-      return 200;
-    case ALTEIRIANS:
-      return 50;
-    case SMAUGIRIANS:
-      return 100;
-    case SYNTHDROIDS:
-      return 100;
-    default:
-      return 0;
+    var result = 100;
+    if (hasTrait(TraitIds.STRONG)) {
+      result += 50;
     }
+    if (hasTrait(TraitIds.WEAK)) {
+      result -= 50;
+    }
+    if (isLithovorian()) {
+      result += 50;
+    }
+    return result;
   }
 
   /**
@@ -685,42 +674,20 @@ public enum SpaceRace {
    * @return normal 10
    */
   public int getTrooperPower() {
-    switch (this) {
-    case HUMAN:
-    case SPACE_PIRATE:
-    case SPACE_MONSTERS:
-      return 10;
-    case MECHIONS:
-      return 12;
-    case SPORKS:
-      return 12;
-    case GREYANS:
-      return 8;
-    case CENTAURS:
-      return 14;
-    case MOTHOIDS:
-      return 9;
-    case TEUTHIDAES:
-      return 10;
-    case SCAURIANS:
-      return 10;
-    case HOMARIANS:
-      return 11;
-    case CHIRALOIDS:
-      return 9;
-    case REBORGIANS:
-      return 13;
-    case LITHORIANS:
-      return 12;
-    case ALTEIRIANS:
-      return 6;
-    case SMAUGIRIANS:
-      return 11;
-    case SYNTHDROIDS:
-      return 10;
-    default:
-      return 0;
+    var result = 10;
+    if (hasTrait(TraitIds.STRONG)) {
+      result += 2;
     }
+    if (hasTrait(TraitIds.WEAK)) {
+      result -= 2;
+    }
+    if (hasTrait(TraitIds.SLOW_METABOLISM)) {
+      result -= 1;
+    }
+    if (hasTrait(TraitIds.MASSIVE_SIZE)) {
+      result += 2;
+    }
+    return result;
   }
 
   /**

--- a/src/main/java/org/openRealmOfStars/player/race/trait/TraitIds.java
+++ b/src/main/java/org/openRealmOfStars/player/race/trait/TraitIds.java
@@ -117,6 +117,10 @@ public final class TraitIds {
   public static final String REPULSIVE = "REPULSIVE";
   /** Race's habits/looks are unnaceptable to others, diplomacy is futile */
   public static final String DISGUSTING = "DISGUSTING";
+  /** Unnaturally strong for it's size */
+  public static final String STRONG = "STRONG";
+  /** Race is weaker than usual */
+  public static final String WEAK = "WEAK";
 
   /** List storing all hardcoded IDs. Populated at runtime, via reflection. */
   private static List<String> hardcodedIds = null;

--- a/src/main/java/org/openRealmOfStars/player/race/trait/TraitIds.java
+++ b/src/main/java/org/openRealmOfStars/player/race/trait/TraitIds.java
@@ -121,6 +121,10 @@ public final class TraitIds {
   public static final String STRONG = "STRONG";
   /** Race is weaker than usual */
   public static final String WEAK = "WEAK";
+  /** Be it due to anatomy or cognitive abilities, race exhibits handiness */
+  public static final String HANDY = "HANDY";
+  /** Due to body anatomy or cognitive abilites, working is difficult */
+  public static final String IMPRACTICAL = "IMPRACTICAL";
 
   /** List storing all hardcoded IDs. Populated at runtime, via reflection. */
   private static List<String> hardcodedIds = null;

--- a/src/main/resources/resources/data/traits/base.json
+++ b/src/main/resources/resources/data/traits/base.json
@@ -293,5 +293,23 @@
     "conflictsWith": [
       "STRONG"
     ]
+  },
+  {
+    "id": "HANDY",
+    "name": "Handy",
+    "description": "Whether it is due to anatomy or cognitive abilities, race exhibits unnatural handiness, benefiting production.",
+    "points": 2,
+    "conflictsWith": [
+      "IMPRACTICAL"
+    ]
+  },
+  {
+    "id": "IMPRACTICAL",
+    "name": "Impractical",
+    "description": "Anatomy or cognitive abilities of the race negatively impact it's production capabilities.",
+    "points": -2,
+    "conflictsWith": [
+      "HANDY"
+    ]
   }
 ]

--- a/src/main/resources/resources/data/traits/base.json
+++ b/src/main/resources/resources/data/traits/base.json
@@ -8,7 +8,7 @@
   {
     "id": "LITHOVORIC",
     "name": "Lithovoric",
-    "description": "Eats minerals instead of food.",
+    "description": "Eats minerals instead of food. This life-long bond with earth consquently results in talent for mining.",
     "points": 0,
     "conflictsWith": [
       "ENERGY_POWERED", "FAST_FOOD_PROD"
@@ -187,7 +187,7 @@
     "id": "MASSIVE_SIZE",
     "name": "Massive size",
     "description": "Massive size, that ships are more robust and leaders live a longer life.",
-    "points": 2
+    "points": 3
   },
   {
     "id": "SLOW_METABOLISM",
@@ -274,6 +274,24 @@
     "points": -3,
     "conflictsWith": [
       "NATURAL_CHARM", "REPULSIVE"
+    ]
+  },
+  {
+    "id": "STRONG",
+    "name": "Strong",
+    "description": "Unnaturally strong for it's size. Race's troops are more powerful and mining minerals is easier.",
+    "points": 2,
+    "conflictsWith": [
+      "WEAK"
+    ]
+  },
+  {
+    "id": "WEAK",
+    "name": "Weak",
+    "description": "Race is weaker than usual. This weakness is negatively impacting it's combat abilities, as well as labor work.",
+    "points": -2,
+    "conflictsWith": [
+      "STRONG"
     ]
   }
 ]


### PR DESCRIPTION
Add Strong and Weak traits, that give bonus/malus to troop power and mining production.
Add "Handy" (needs better name) and Impractical traits that add bonus/malus to production.
Tweak Lithovoric trait to give bonus to mining, as a compensation for continuous mineral consumption.