### PR TITLE
Use Zero-G trait, modify Radiation Tolerance trait

### DIFF
--- a/src/main/java/org/openRealmOfStars/ai/mission/MissionHandling.java
+++ b/src/main/java/org/openRealmOfStars/ai/mission/MissionHandling.java
@@ -49,6 +49,7 @@ import org.openRealmOfStars.player.leader.stats.StatType;
 import org.openRealmOfStars.player.message.Message;
 import org.openRealmOfStars.player.message.MessageType;
 import org.openRealmOfStars.player.race.SpaceRace;
+import org.openRealmOfStars.player.race.trait.TraitIds;
 import org.openRealmOfStars.player.ship.Ship;
 import org.openRealmOfStars.player.ship.ShipHullType;
 import org.openRealmOfStars.player.ship.ShipStat;
@@ -866,9 +867,11 @@ public final class MissionHandling {
           // Make sure that ship is really colony and there is planet to
           // colonize
           planet.setPlanetOwner(game.getStarMap().getAiTurnNumber(), info);
-          if (info.getRace() == SpaceRace.ALTEIRIANS) {
+          // Zero-G beings colonize with orbitals
+          if (info.getRace().hasTrait(TraitIds.ZERO_GRAVITY_BEING)) {
             planet.colonizeWithOrbital();
           }
+
           if (!info.getRace().isEatingFood()) {
             planet.setWorkers(Planet.PRODUCTION_WORKERS, ship.getColonist());
           } else {

--- a/src/main/java/org/openRealmOfStars/ai/planet/DefaultScoring.java
+++ b/src/main/java/org/openRealmOfStars/ai/planet/DefaultScoring.java
@@ -27,7 +27,6 @@ import org.openRealmOfStars.player.diplomacy.Attitude;
 import org.openRealmOfStars.player.diplomacy.DiplomacyBonusList;
 import org.openRealmOfStars.player.espionage.EspionageList;
 import org.openRealmOfStars.player.government.GovernmentType;
-import org.openRealmOfStars.player.race.SpaceRace;
 import org.openRealmOfStars.player.race.trait.TraitIds;
 import org.openRealmOfStars.player.ship.Ship;
 import org.openRealmOfStars.player.ship.ShipHullType;
@@ -636,10 +635,12 @@ public final class DefaultScoring {
     score = score - ship.getMetalCost() / 10;
     score = score - ship.getProdCost() / 10;
     if (ship.getHull().getHullType() == ShipHullType.ORBITAL) {
-      if (planet.getPlanetPlayerInfo().getRace() == SpaceRace.ALTEIRIANS) {
-        // Alteirians should built orbitals more frequently
+      // Zero-G races should built orbitals more frequently
+      if (planet.getPlanetPlayerInfo().getRace()
+          .hasTrait(TraitIds.ZERO_GRAVITY_BEING)) {
         score += 50;
       }
+
       score = score + ship.getHull().getSize().getMass() * 5;
       if (ship.getHull().getName().startsWith("Minor orbital")) {
         // Minor orbital should not be built.

--- a/src/main/java/org/openRealmOfStars/ai/planet/PlanetHandling.java
+++ b/src/main/java/org/openRealmOfStars/ai/planet/PlanetHandling.java
@@ -29,7 +29,6 @@ import org.openRealmOfStars.player.diplomacy.Attitude;
 import org.openRealmOfStars.player.leader.LeaderUtility;
 import org.openRealmOfStars.player.message.Message;
 import org.openRealmOfStars.player.message.MessageType;
-import org.openRealmOfStars.player.race.SpaceRace;
 import org.openRealmOfStars.player.race.trait.TraitIds;
 import org.openRealmOfStars.player.ship.Ship;
 import org.openRealmOfStars.player.ship.ShipHullType;
@@ -576,7 +575,7 @@ public final class PlanetHandling {
               mission.setPlanetBuilding(planet.getName());
               break;
             }
-            if (info.getRace() == SpaceRace.ALTEIRIANS) {
+            if (info.getRace().hasTrait(TraitIds.ZERO_GRAVITY_BEING)) {
               mission = info.getMissions().getMissionForPlanet(
                   planet.getName(), MissionType.DEFEND);
               if (mission != null && ship.getTotalMilitaryPower() > 0

--- a/src/main/java/org/openRealmOfStars/game/Game.java
+++ b/src/main/java/org/openRealmOfStars/game/Game.java
@@ -115,6 +115,7 @@ import org.openRealmOfStars.player.message.ChangeMessagePlanet;
 import org.openRealmOfStars.player.message.Message;
 import org.openRealmOfStars.player.message.MessageType;
 import org.openRealmOfStars.player.race.SpaceRace;
+import org.openRealmOfStars.player.race.trait.TraitIds;
 import org.openRealmOfStars.player.ship.Ship;
 import org.openRealmOfStars.player.ship.ShipComponent;
 import org.openRealmOfStars.player.ship.ShipComponentFactory;
@@ -2545,23 +2546,25 @@ public class Game implements ActionListener {
     Ship ship = fleetView.getFleet().getColonyShip();
     if (ship != null && fleetView.getPlanet() != null
         && fleetView.getPlanet().getPlanetPlayerInfo() == null) {
+      final var currPlayer = players.getCurrentPlayerInfo();
       // Make sure that ship is really colony and there is planet to
       // colonize
       fleetView.getPlanet().setPlanetOwner(players.getCurrentPlayer(),
-          players.getCurrentPlayerInfo());
-      if (players.getCurrentPlayerInfo().getRace() == SpaceRace.ALTEIRIANS) {
+          currPlayer);
+      if (currPlayer.getRace().hasTrait(TraitIds.ZERO_GRAVITY_BEING)) {
         fleetView.getPlanet().colonizeWithOrbital();
       }
-      if (players.getCurrentPlayerInfo().getRace().getFoodRequire() == 0) {
+      if (currPlayer.getRace().getFoodRequire() == 0) {
         fleetView.getPlanet().setWorkers(Planet.PRODUCTION_WORKERS,
             ship.getColonist());
-      } else if (players.getCurrentPlayerInfo().getRace().isLithovorian()) {
+      } else if (currPlayer.getRace().isLithovorian()) {
         fleetView.getPlanet().setWorkers(Planet.METAL_MINERS,
             ship.getColonist());
       } else {
         fleetView.getPlanet().setWorkers(Planet.FOOD_FARMERS,
             ship.getColonist());
       }
+
       // Remove the ship and show the planet view you just colonized
       fleetView.getFleet().removeShip(ship);
       ShipStat stat = starMap.getCurrentPlayerInfo()
@@ -2576,7 +2579,7 @@ public class Game implements ActionListener {
         fleetView.getPlanet().getGovernor().setTitle(
             LeaderUtility.createTitleForLeader(
                 fleetView.getPlanet().getGovernor(),
-                players.getCurrentPlayerInfo()));
+                currPlayer));
         fleetView.getFleet().setCommander(null);
       }
       fleetView.getFleetList().recalculateList();
@@ -2586,7 +2589,7 @@ public class Game implements ActionListener {
       EventOnPlanet event = new EventOnPlanet(EventType.PLANET_COLONIZED,
           fleetView.getPlanet().getCoordinate(),
           fleetView.getPlanet().getName(), players.getCurrentPlayer());
-      event.setText(players.getCurrentPlayerInfo().getEmpireName()
+      event.setText(currPlayer.getEmpireName()
           + " colonized planet " + fleetView.getPlanet().getName()
           + ". ");
       SoundPlayer.playSound(SoundPlayer.COLONIZED);

--- a/src/main/java/org/openRealmOfStars/game/state/PlanetBombingView.java
+++ b/src/main/java/org/openRealmOfStars/game/state/PlanetBombingView.java
@@ -61,7 +61,6 @@ import org.openRealmOfStars.player.leader.Job;
 import org.openRealmOfStars.player.leader.Perk;
 import org.openRealmOfStars.player.message.Message;
 import org.openRealmOfStars.player.message.MessageType;
-import org.openRealmOfStars.player.race.SpaceRace;
 import org.openRealmOfStars.player.race.trait.TraitIds;
 import org.openRealmOfStars.player.ship.Ship;
 import org.openRealmOfStars.player.ship.ShipComponent;
@@ -955,7 +954,7 @@ public class PlanetBombingView extends BlackPanel {
     ship.setColonist(0);
 
     planet.setPlanetOwner(attackPlayerIndex, attacker);
-    if (attacker.getRace() == SpaceRace.ALTEIRIANS) {
+    if (attacker.getRace().hasTrait(TraitIds.ZERO_GRAVITY_BEING)) {
       planet.colonizeWithOrbital();
     }
     result.conquered = true;

--- a/src/main/java/org/openRealmOfStars/player/combat/Combat.java
+++ b/src/main/java/org/openRealmOfStars/player/combat/Combat.java
@@ -40,6 +40,7 @@ import org.openRealmOfStars.player.leader.stats.StatType;
 import org.openRealmOfStars.player.message.Message;
 import org.openRealmOfStars.player.message.MessageType;
 import org.openRealmOfStars.player.race.SpaceRace;
+import org.openRealmOfStars.player.race.trait.TraitIds;
 import org.openRealmOfStars.player.ship.Ship;
 import org.openRealmOfStars.player.ship.ShipComponent;
 import org.openRealmOfStars.player.ship.ShipComponentType;
@@ -780,8 +781,9 @@ public boolean launchIntercept(final int distance,
           Icons.getIconByName(Icons.ICON_STARBASE));
       msg.setMatchByString(planet.getName());
       defenderInfo.getMsgList().addNewMessage(msg);
-      if (planet.getPlanetPlayerInfo() != null
-          && planet.getPlanetPlayerInfo().getRace() == SpaceRace.ALTEIRIANS) {
+      final var planetOwner = planet.getPlanetPlayerInfo();
+      if (planetOwner != null
+          && planetOwner.getRace().hasTrait(TraitIds.ZERO_GRAVITY_BEING)) {
         orbitalDestroyedNews = NewsFactory.makeAlteirianLoseOrbitalNews(
             attackerInfo, defenderInfo, planet, attackerPrivateer);
         planet.setWorkers(Planet.PRODUCTION_WORKERS, 0);

--- a/src/main/java/org/openRealmOfStars/player/diplomacy/DiplomaticTrade.java
+++ b/src/main/java/org/openRealmOfStars/player/diplomacy/DiplomaticTrade.java
@@ -41,6 +41,7 @@ import org.openRealmOfStars.player.message.Message;
 import org.openRealmOfStars.player.message.MessageType;
 import org.openRealmOfStars.player.race.SpaceRace;
 import org.openRealmOfStars.player.race.SpaceRaceUtility;
+import org.openRealmOfStars.player.race.trait.TraitIds;
 import org.openRealmOfStars.player.tech.Tech;
 import org.openRealmOfStars.player.tech.TechList;
 import org.openRealmOfStars.player.tech.TechType;
@@ -2791,9 +2792,11 @@ public class DiplomaticTrade {
           planet.setGovernor(null);
         }
         planet.setPlanetOwner(index, info);
-        if (info.getRace() == SpaceRace.ALTEIRIANS) {
+
+        if (info.getRace().hasTrait(TraitIds.ZERO_GRAVITY_BEING)) {
           planet.colonizeWithOrbital();
         }
+
         sb.append(info.getEmpireName());
         switch (DiceGenerator.getRandom(2)) {
           case 0:

--- a/src/main/java/org/openRealmOfStars/player/race/SpaceRace.java
+++ b/src/main/java/org/openRealmOfStars/player/race/SpaceRace.java
@@ -353,16 +353,9 @@ public enum SpaceRace {
     TraitFactory.create(TraitIds.ZERO_GRAVITY_BEING).ifPresent(trait -> {
       ALTEIRIANS.addTrait(trait);
     });
-    TraitFactory.create(TraitIds.TOLERATE_LOW_RADIATION).ifPresent(trait -> {
-      HUMAN.addTrait(trait);
-      SPACE_PIRATE.addTrait(trait);
-      SPACE_MONSTERS.addTrait(trait);
-      SPORKS.addTrait(trait);
-      SCAURIANS.addTrait(trait);
-      REBORGIANS.addTrait(trait);
-      TEUTHIDAES.addTrait(trait);
-      SMAUGIRIANS.addTrait(trait);
-      SYNTHDROIDS.addTrait(trait);
+    TraitFactory.create(TraitIds.TOLERATE_NO_RADIATION).ifPresent(trait -> {
+      CENTAURS.addTrait(trait);
+      HOMARIANS.addTrait(trait);
     });
     TraitFactory.create(TraitIds.TOLERATE_HIGH_RADIATION).ifPresent(trait -> {
       GREYANS.addTrait(trait);
@@ -370,7 +363,7 @@ public enum SpaceRace {
       LITHORIANS.addTrait(trait);
       MOTHOIDS.addTrait(trait);
     });
-    TraitFactory.create(TraitIds.TOLERATE_VERY_HIGH_RADIATION).ifPresent(
+    TraitFactory.create(TraitIds.TOLERATE_EXTREME_RADIATION).ifPresent(
         trait -> {
       MECHIONS.addTrait(trait);
       CHIRALOIDS.addTrait(trait);
@@ -541,14 +534,14 @@ public enum SpaceRace {
    * @return The race maximum radiation
    */
   public RadiationType getMaxRad() {
-    RadiationType result = RadiationType.NO_RADIATION;
-    if (hasTrait(TraitIds.TOLERATE_LOW_RADIATION)) {
-      result = RadiationType.LOW_RADIATION;
+    RadiationType result = RadiationType.LOW_RADIATION;
+    if (hasTrait(TraitIds.TOLERATE_NO_RADIATION)) {
+      result = RadiationType.NO_RADIATION;
     }
     if (hasTrait(TraitIds.TOLERATE_HIGH_RADIATION)) {
       result = RadiationType.HIGH_RADIATION;
     }
-    if (hasTrait(TraitIds.TOLERATE_VERY_HIGH_RADIATION)) {
+    if (hasTrait(TraitIds.TOLERATE_EXTREME_RADIATION)) {
       result = RadiationType.VERY_HIGH_RAD;
     }
     return result;

--- a/src/main/java/org/openRealmOfStars/player/race/trait/TraitIds.java
+++ b/src/main/java/org/openRealmOfStars/player/race/trait/TraitIds.java
@@ -131,14 +131,14 @@ public final class TraitIds {
   public static final String HIGH_GRAVITY_BEING = "HIGH_GRAVITY_BEING";
   /** Race is used to work in zero gravity conditions. */
   public static final String ZERO_GRAVITY_BEING = "ZERO_GRAVITY_BEING";
-  /** Tolerate low radiation on planets. */
-  public static final String TOLERATE_LOW_RADIATION = "TOLERATE_LOW_RADIATION";
+  /** Tolerate only very little radiation on planets. */
+  public static final String TOLERATE_NO_RADIATION = "TOLERATE_NO_RADIATION";
   /** Tolerate high radiation on planets. */
   public static final String TOLERATE_HIGH_RADIATION =
       "TOLERATE_HIGH_RADIATION";
   /** Tolerate very high radiation on planets. */
-  public static final String TOLERATE_VERY_HIGH_RADIATION =
-      "TOLERATE_VERY_HIGH_RADIATION";
+  public static final String TOLERATE_EXTREME_RADIATION =
+      "TOLERATE_EXTREME_RADIATION";
   /** Tolerate cold temperature on planets. */
   public static final String TOLERATE_COLD = "TOLERATE_COLD";
   /** Tolerate hot temperature on planets. */

--- a/src/main/java/org/openRealmOfStars/player/ship/ShipHull.java
+++ b/src/main/java/org/openRealmOfStars/player/ship/ShipHull.java
@@ -150,7 +150,9 @@ public class ShipHull {
       this.metalCost = this.metalCost * 2;
       this.cost = this.cost * 3 / 2;
     }
-    if (race == SpaceRace.ALTEIRIANS && this.hullType == ShipHullType.ORBITAL) {
+    // Zero-G races have greatly lowered price of orbitals
+    if (race.hasTrait(TraitIds.ZERO_GRAVITY_BEING)
+        && this.hullType == ShipHullType.ORBITAL) {
       this.metalCost = this.metalCost / 2;
       this.cost = this.cost / 2;
     }

--- a/src/main/java/org/openRealmOfStars/player/ship/generator/ShipGenerator.java
+++ b/src/main/java/org/openRealmOfStars/player/ship/generator/ShipGenerator.java
@@ -1579,9 +1579,9 @@ public final class ShipGenerator {
       if (DiceGenerator.getRandom(99) < militaryChance) {
         military = true;
       }
-      if (player.getRace() == SpaceRace.ALTEIRIANS) {
+      // Zero-G races will lose planet if orbital is lost.
+      if (player.getRace().hasTrait(TraitIds.ZERO_GRAVITY_BEING)) {
         military = true;
-        // Alteirians will lose planet if orbital is lost.
       }
       if (military || player.isBoard()) {
         ShipComponent weapon = ShipComponentFactory

--- a/src/main/java/org/openRealmOfStars/starMap/StarMap.java
+++ b/src/main/java/org/openRealmOfStars/starMap/StarMap.java
@@ -59,6 +59,7 @@ import org.openRealmOfStars.player.message.Message;
 import org.openRealmOfStars.player.message.MessageType;
 import org.openRealmOfStars.player.race.BackgroundStoryGenerator;
 import org.openRealmOfStars.player.race.SpaceRace;
+import org.openRealmOfStars.player.race.trait.TraitIds;
 import org.openRealmOfStars.player.ship.Ship;
 import org.openRealmOfStars.player.ship.ShipHullType;
 import org.openRealmOfStars.player.ship.ShipStat;
@@ -1736,7 +1737,7 @@ public class StarMap {
       //where is another realm's home planet.
     }
     planet.setPlanetOwner(playerIndex, playerInfo);
-    if (playerInfo.getRace() == SpaceRace.ALTEIRIANS) {
+    if (playerInfo.getRace().hasTrait(TraitIds.ZERO_GRAVITY_BEING)) {
       planet.colonizeWithOrbital();
     }
     if (Game.getTutorial() != null && playerInfo.isHuman()
@@ -1783,7 +1784,7 @@ public class StarMap {
       playerInfo.setRuler(ruler);
     }
 
-    if (playerInfo.getRace() != SpaceRace.ALTEIRIANS
+    if (!playerInfo.getRace().hasTrait(TraitIds.ZERO_GRAVITY_BEING)
         && !planet.hasSpacePort()) {
        if (planet.getBuildingList().length >= planet.getGroundSize()) {
          // Planet is full and no space for space port.

--- a/src/main/java/org/openRealmOfStars/starMap/planet/Planet.java
+++ b/src/main/java/org/openRealmOfStars/starMap/planet/Planet.java
@@ -3076,7 +3076,7 @@ public class Planet {
       }
     }
     if (planetOwnerInfo != null
-        && planetOwnerInfo.getRace() == SpaceRace.ALTEIRIANS) {
+        && planetOwnerInfo.getRace().hasTrait(TraitIds.ZERO_GRAVITY_BEING)) {
       result = 0;
       if (getPlanetType() == PlanetTypes.ARTIFICIALWORLD1) {
         result = getGroundSize();

--- a/src/main/resources/resources/data/traits/base.json
+++ b/src/main/resources/resources/data/traits/base.json
@@ -340,12 +340,12 @@
     ]
   },
   {
-    "id": "TOLERATE_LOW_RADIATION",
-    "name": "Tolerate low radiation",
-    "description": "Race is able to tolerate low radiation on planets.",
-    "points": 1,
+    "id": "TOLERATE_NO_RADIATION",
+    "name": "Radiation intolerant",
+    "description": "Race does not handle radiation well, and is able tolerate only very small levels of radiation on planets.",
+    "points": -1,
     "conflictsWith": [
-      "TOLERATE_HIGH_RADIATION","TOLERATE_VERY_HIGH_RADIATION"
+      "TOLERATE_HIGH_RADIATION","TOLERATE_EXTREME_RADIATION"
     ]
   },
   {
@@ -354,13 +354,13 @@
     "description": "Race is able to tolerate high radiation on planets.",
     "points": 2,
     "conflictsWith": [
-      "TOLERATE_LOW_RADIATION","TOLERATE_VERY_HIGH_RADIATION"
+      "TOLERATE_LOW_RADIATION","TOLERATE_EXTREME_RADIATION"
     ]
   },
   {
-    "id": "TOLERATE_VERY_HIGH_RADIATION",
-    "name": "Tolerate very high radiation",
-    "description": "Race is able to tolerate very high radiation on planets.",
+    "id": "TOLERATE_EXTREME_RADIATION",
+    "name": "Tolerate extreme radiation",
+    "description": "Race is able to tolerate extremely high radiation on planets.",
     "points": 3,
     "conflictsWith": [
       "TOLERATE_LOW_RADIATION","TOLERATE_HIGH_RADIATION"


### PR DESCRIPTION
"Zero Gravity Being" `RaceTrait` is used in code where appropriate instead of hardcoded SpaceRace.

"Low Radiation Tolerance" `RaceTrait` introduced as part of #716 is removed and replaced with "Radiation Intolerance".
This fixes trait design issue, where common case - tolerance of low radiation - was a trait, while rare case - zero/minimal radiation tolerance - was assumed as default ("implicit trait"). Races which cannot survive on world with low radiation (common level of radiation) now have "Radiation Intolerance", while races that are able to handle maximum of "normal" level of radiation have no radiation-related `RaceTrait`.
This change also helps with *balancing trait points* a little, as no/minimal radiation tolerance is considered a "bad" trait.

Very High Radiation tolerance was renamed to Extreme Radiation tolerance, to better mark how significant the trait is.