### PR TITLE
Format Diplomacy code

### DIFF
--- a/src/main/java/org/openRealmOfStars/gui/util/GuiFonts.java
+++ b/src/main/java/org/openRealmOfStars/gui/util/GuiFonts.java
@@ -200,8 +200,7 @@ public final class GuiFonts {
    */
   private static Optional<Font> getFontFromCache(final URL fontUrl,
       final float baseSize) {
-    return GuiFonts.getFontFromCache(fontUrl, baseSize,
-        GuiFonts.fontScalingFactor);
+    return getFontFromCache(fontUrl, baseSize, fontScalingFactor);
   }
 
   /**

--- a/src/main/java/org/openRealmOfStars/player/diplomacy/Attitude.java
+++ b/src/main/java/org/openRealmOfStars/player/diplomacy/Attitude.java
@@ -26,42 +26,23 @@ import org.openRealmOfStars.utilities.DiceGenerator;
 */
 public enum Attitude {
 
-  /**
-   * Aggressive AI attacking often, making threats.
-   */
+  /** Aggressive AI attacking often, making threats. */
   AGGRESSIVE,
-  /**
-   * Diplomatic tries to be nice with every one.
-   */
+  /** Diplomatic tries to be nice with every one. */
   DIPLOMATIC,
-  /**
-   * Scientist tries to achieve more knowledge.
-   */
+  /** Scientist tries to achieve more knowledge. */
   SCIENTIFIC,
-  /**
-   * Tries to search galaxy fully and conquer as many planet as possible.
-   */
+  /** Tries to search galaxy fully and conquer as many planet as possible. */
   EXPANSIONIST,
-  /**
-   * Backstabbing like diplomatic but can make backstabbing move.
-   */
+  /** Backstabbing like diplomatic but can make backstabbing move. */
   BACKSTABBING,
-  /**
-   * Focus more on trading and trading vessels.
-   */
+  /** Focus more on trading and trading vessels. */
   MERCHANTICAL,
-  /**
-   * Military focus on military things, slightly aggressive but very
-   * trustworthy.
-   */
+  /** Focus on military things, slightly aggressive but very trustworthy. */
   MILITARISTIC,
-  /**
-   * Peaceful tries to avoid conflict at any cost
-   */
+  /** Peaceful tries to avoid conflict at any cost */
   PEACEFUL,
-  /**
-   * Logical very basic AI that tries to do everything with simple logic.
-   */
+  /** Logical very basic AI that tries to do everything with simple logic. */
   LOGICAL;
 
   /**

--- a/src/main/java/org/openRealmOfStars/player/diplomacy/AttitudeScore.java
+++ b/src/main/java/org/openRealmOfStars/player/diplomacy/AttitudeScore.java
@@ -18,18 +18,13 @@ package org.openRealmOfStars.player.diplomacy;
  */
 
 /**
-*
-* Attitude scoring for rulers
-*/
+ * Attitude scoring for rulers
+ */
 public class AttitudeScore implements Comparable<AttitudeScore> {
 
-  /**
-   * Attitude
-   */
+  /** Attitude */
   private Attitude attitude;
-  /**
-   * Scoring value
-   */
+  /** Scoring value */
   private int value;
 
   /**
@@ -40,6 +35,7 @@ public class AttitudeScore implements Comparable<AttitudeScore> {
     this.attitude = attitude;
     value = 0;
   }
+
   @Override
   public int compareTo(final AttitudeScore arg0) {
     return this.value - arg0.value;
@@ -60,6 +56,7 @@ public class AttitudeScore implements Comparable<AttitudeScore> {
   public int getValue() {
     return value;
   }
+
   /**
    * Set Value for attitude
    * @param value the value to set
@@ -67,6 +64,5 @@ public class AttitudeScore implements Comparable<AttitudeScore> {
   public void setValue(final int value) {
     this.value = value;
   }
-
 
 }

--- a/src/main/java/org/openRealmOfStars/player/diplomacy/Diplomacy.java
+++ b/src/main/java/org/openRealmOfStars/player/diplomacy/Diplomacy.java
@@ -33,108 +33,68 @@ import org.openRealmOfStars.starMap.StarMap;
 import org.openRealmOfStars.starMap.StarMapUtilities;
 
 /**
-*
-* Diplomacy for player and handling of it.
-* Diplomacy creates Diplomacy Bonus lists for all players
-* except the one who is creating the Diplomacy.
-*
-*/
+ * Diplomacy for player and handling of it.
+ * Diplomacy creates Diplomacy Bonus lists for all players
+ * except the one who is creating the Diplomacy.
+ */
 public class Diplomacy {
 
-  /**
-   * How much player likes another one: Neutral
-   */
+  /** How much player likes another one: Neutral */
   public static final int NEUTRAL = 0;
-
-  /**
-   * How much player likes another one: Like
-   */
+  /** How much player likes another one: Like */
   public static final int LIKE = 1;
-
-  /**
-   * How much player likes another one: Friends
-   */
+  /** How much player likes another one: Friends */
   public static final int FRIENDS = 2;
-
-  /**
-   * How much player likes another one: Dislike
-   */
+  /** How much player likes another one: Dislike */
   public static final int DISLIKE = -1;
-
-  /**
-   * How much player likes another one: Hate
-   */
+  /** How much player likes another one: Hate */
   public static final int HATE = -2;
-  /**
-   * Limit when realm has casus belli.
-   */
+
+  /** Limit when realm has casus belli. */
   public static final int CASUS_BELLI_LIMIT = 20;
 
-  /**
-   * String for Trade Alliance.
-   */
+  /** String for Trade Alliance. */
   public static final String TRADE_ALLIANCE = "Trade alliance";
-
-  /**
-   * String for Peace.
-   */
+  /** String for Peace. */
   public static final String PEACE = "Peace";
-
-  /**
-   * No diplomatic relation yet.
-   */
+  /** No diplomatic relation yet. */
   public static final String NO_RELATION = "";
-  /**
-   * String for Alliance.
-   */
+  /** String for Alliance. */
   public static final String ALLIANCE = "Alliance";
-
-  /**
-   * String for Defensive pact.
-   */
+  /** String for Defensive pact. */
   public static final String DEFENSIVE_PACT = "Defensive pact";
-
-  /**
-   * String for War.
-   */
+  /** String for War. */
   public static final String WAR = "War";
-  /**
-   * String for Trade embargo
-   */
+  /** String for Trade embargo */
   public static final String TRADE_EMBARGO = "Trade embargo";
 
-  /**
-   * Relation int for WAR
-   */
+  /** Relation int for WAR */
   public static final int RELATION_WAR = -2;
-  /**
-   * Relation int for TRADE_WAR
-   */
+  /** Relation int for TRADE_WAR */
   public static final int RELATION_TRADE_WAR = -1;
-  /**
-   * Relation int for no relation
-   */
+  /** Relation int for no relation */
   public static final int RELATION_NO_RELATION = 0;
-  /**
-   * Relation int for peace
-   */
+  /** Relation int for peace */
   public static final int RELATION_PEACE = 1;
-  /**
-   * Relation int for trade alliance
-   */
+  /** Relation int for trade alliance */
   public static final int RELATION_TRADE_ALLIANCE = 2;
-  /**
-   * Relation int for defensive pact
-   */
+  /** Relation int for defensive pact */
   public static final int RELATION_DEFENSIVE_PACT = 3;
-  /**
-   * Relation int for alliance
-   */
+  /** Relation int for alliance */
   public static final int RELATION_ALLIANCE = 4;
 
-  /**
-   * Diplomacy Bonus list for each player
-   */
+  /** Lowest value for neutral */
+  private static final int LOW_NEUTRAL = -10;
+  /** High value for neutral */
+  private static final int HIGH_NEUTRAL = 10;
+  /** Low value for dislike */
+  private static final int LOW_DISLIKE = -20;
+  /** High value for like */
+  private static final int HIGH_LIKE = 20;
+  /** Very High value for looking least liking */
+  private static final int VERY_HIGH_LIKE = 9999;
+
+  /** Diplomacy Bonus list for each player */
   private DiplomacyBonusList[] diplomacyList;
 
   /**
@@ -367,31 +327,6 @@ public class Diplomacy {
     }
     return -1;
   }
-
-  /**
-   * Lowest value for neutral
-   */
-  private static final int LOW_NEUTRAL = -10;
-
-  /**
-   * High value for neutral
-   */
-  private static final int HIGH_NEUTRAL = 10;
-
-  /**
-   * Low value for dislike
-   */
-  private static final int LOW_DISLIKE = -20;
-
-  /**
-   * High value for like
-   */
-  private static final int HIGH_LIKE = 20;
-
-  /**
-   * Very High value for looking least liking
-   */
-  private static final int VERY_HIGH_LIKE = 9999;
 
   /**
    * Get numeric value how much player likes another player.

--- a/src/main/java/org/openRealmOfStars/player/diplomacy/DiplomacyBonus.java
+++ b/src/main/java/org/openRealmOfStars/player/diplomacy/DiplomacyBonus.java
@@ -20,10 +20,22 @@ package org.openRealmOfStars.player.diplomacy;
 import org.openRealmOfStars.player.race.SpaceRace;
 
 /**
-*
-* Diplomacy Bonus
-*/
+ * Diplomacy Bonus
+ */
 public class DiplomacyBonus {
+
+  /** Diplomacy Bonus type */
+  private DiplomacyBonusType type;
+  /** Only one this kind of bonus allowed in list */
+  private boolean onlyOne;
+  /** Bonus value for diplomacy. This can be both negative or positive */
+  private int bonusValue;
+  /**
+   * How long bonus has lasted or how many star years ago something happened.
+   * Value 255 means that it will last for ever unless something happens
+   * if Value goes zero then bonusValue goes also zero.
+   */
+  private int bonusLasting;
 
   /**
    * Create diplomacy bonus with certain type.
@@ -481,28 +493,6 @@ public class DiplomacyBonus {
       }
     }
   }
-
-  /**
-   * Diplomacy Bonus type
-   */
-  private DiplomacyBonusType type;
-
-  /**
-   * Only one this kind of bonus allowed in list
-   */
-  private boolean onlyOne;
-
-  /**
-   * Bonus value for diplomacy. This can be both negative or positive
-   */
-  private int bonusValue;
-
-  /**
-   * How long bonus has lasted or how many star years ago something happened.
-   * Value 255 means that it will last for ever unless something happens
-   * if Value goes zero then bonusValue goes also zero.
-   */
-  private int bonusLasting;
 
   /**
    * Get the Diplomacy bonus value

--- a/src/main/java/org/openRealmOfStars/player/diplomacy/DiplomacyBonusList.java
+++ b/src/main/java/org/openRealmOfStars/player/diplomacy/DiplomacyBonusList.java
@@ -25,26 +25,16 @@ import org.openRealmOfStars.player.race.SpaceRace;
 import org.openRealmOfStars.starMap.vote.sports.VotingChoice;
 
 /**
-*
-* Diplomacy Bonus List and handling of it. This is list of diplomacy
-* bonus for certain player.
-*
-*/
+ * Diplomacy Bonus List and handling of it. This is list of diplomacy
+ * bonus for certain player.
+ */
 public class DiplomacyBonusList {
 
-  /**
-   * This is for saving PlayerInfo index for saved game
-   */
+  /** This is for saving PlayerInfo index for saved game */
   private int playerIndex;
-
-  /**
-   * Diplomacy Bonus list
-   */
+  /** Diplomacy Bonus list */
   private List<DiplomacyBonus> list;
-
-  /**
-   * Number of diplomatic meetings
-   */
+  /** Number of diplomatic meetings */
   private int numberOfMeetings;
 
   /**
@@ -97,14 +87,15 @@ public class DiplomacyBonusList {
    * @return Casus belli reason.
    */
   public String getMostCassusBelli() {
-    int[] score = new int[DiplomacyBonusType.MAX_BONUS_TYPE];
+    final var bonusTypeCount = DiplomacyBonusType.values().length;
+    int[] score = new int[bonusTypeCount];
     for (DiplomacyBonus bonus : list) {
       int i = bonus.getType().getIndex();
       score[i] = score[i] + bonus.getType().getCasusBelliScore();
     }
     int biggestIndex = -1;
     int biggestScore = 0;
-    for (int i = 0; i < DiplomacyBonusType.MAX_BONUS_TYPE; i++) {
+    for (int i = 0; i < bonusTypeCount; i++) {
       if (score[i] > biggestScore) {
         biggestIndex = i;
         biggestScore = score[i];

--- a/src/main/java/org/openRealmOfStars/player/diplomacy/DiplomacyBonusType.java
+++ b/src/main/java/org/openRealmOfStars/player/diplomacy/DiplomacyBonusType.java
@@ -18,10 +18,8 @@ package org.openRealmOfStars.player.diplomacy;
  */
 
 /**
-*
-* Diplomacy Bonus Type
-*
-*/
+ * Diplomacy Bonus Type
+ */
 public enum DiplomacyBonusType {
   /**
    * Two players are in war.
@@ -191,14 +189,6 @@ public enum DiplomacyBonusType {
    */
   SIMILAR_GOVERNMENT_DIFFERENT_GROUP;
 
-
-
-
-  /**
-   * Number of Bonus type. This should be one larger than actual bonus types.
-   */
-  public static final int MAX_BONUS_TYPE = 39;
-
   /**
    * Get DiplomacyBonus index
    * @return int
@@ -350,6 +340,7 @@ public enum DiplomacyBonusType {
           + " Type!");
     }
   }
+
   /**
    * Get Casus belli reason as string
    * @return Casus belli reason
@@ -399,6 +390,7 @@ public enum DiplomacyBonusType {
           + " Type!");
     }
   }
+
   /**
    * Return diplomacy bonus type by index.
    * @param index This must be between 0-10

--- a/src/main/java/org/openRealmOfStars/player/diplomacy/DiplomaticTrade.java
+++ b/src/main/java/org/openRealmOfStars/player/diplomacy/DiplomaticTrade.java
@@ -59,70 +59,35 @@ import org.openRealmOfStars.utilities.DiceGenerator;
  */
 public class DiplomaticTrade {
 
-  /**
-   * Starmap object containing all player infos and map infos.
-   */
+  /** Starmap object containing all player infos and map infos. */
   private StarMap starMap;
 
-  /**
-   * Index for First player.
-   */
+  /** Index for first player. */
   private int first;
-
-  /**
-   * Index for second player.
-   */
+  /** Index for second player. */
   private int second;
 
-  /**
-   * First player is getting in offer.
-   */
+  /** First player is getting in offer. */
   private NegotiationList firstOffer;
-
-  /**
-   * Second player is getting in offer.
-   */
+  /** Second player is getting in offer. */
   private NegotiationList secondOffer;
 
-  /**
-   * Tech List for first player. This list contains techs which first player
-   * is missing.
-   */
+  /** List of Techs which the first player is missing. */
   private ArrayList<Tech> techListForFirst;
-
-  /**
-   * Tech List for second player. This list contains techs which second player
-   * is missing.
-   */
+  /** List of Techs which the second player is missing. */
   private ArrayList<Tech> techListForSecond;
 
-  /**
-   * Fleet list for first player. This list contain fleets which are actually
-   * first player's fleets.
-   */
+  /** List of Fleets of the first player, visible to second player. */
   private ArrayList<Fleet> fleetListForFirst;
-
-  /**
-   * Fleet list for second player. This list contain fleets which are actually
-   * second player's fleet.
-   */
+  /** List of Fleets of the second player, visible to first player. */
   private ArrayList<Fleet> fleetListForSecond;
 
-  /**
-   * Planet list for first player. This list contain planets which are actually
-   * first player's.
-   */
+  /** List of Planets of the first player, visible to second player */
   private ArrayList<Planet> planetListForFirst;
-
-  /**
-   * Planet list for second player. This list contain planets which are actually
-   * second player's.
-   */
+  /** List of Planets of the second player, visible to first player */
   private ArrayList<Planet> planetListForSecond;
 
-  /**
-   * Flag for indicating diplomacy with pirates.
-   */
+  /** Flag for indicating diplomacy with pirates. */
   private boolean diplomacyWithPirates = false;
 
   /**
@@ -131,36 +96,24 @@ public class DiplomaticTrade {
    */
   private String majorDeals;
 
-  /**
-   * Flag for planet traded.
-   */
+  /** Flag for planet traded. */
   private boolean planetTraded;
-  /**
-   * Gift trade.
-   */
+  /** Gift trade. */
   private boolean giftTrade;
-  /**
-   * Difference between two parties which is considered as
-   * insult;
-   */
+
+  /** Difference between two parties which is considered as insult */
   public static final int DECLINE_INSULT = 10000;
 
-  /**
-   * Equal trade
-   */
+  /** Equal trade */
   public static final int TRADE = 0;
-  /**
-   * Buy trade
-   */
+  /** Buy trade */
   public static final int BUY = 1;
-  /**
-   * Sell trade
-   */
+  /** Sell trade */
   public static final int SELL = 2;
-  /**
-   * Power of multiple border crossing.
-   */
+
+  /** Power of multiple border crossing. */
   private static final int BORDER_CROSSING_POWER = 20;
+
   /**
    * Constructor for Diplomatic trade.
    * @param map Starmap
@@ -209,6 +162,7 @@ public class DiplomaticTrade {
   public String getMajorDeals() {
     return majorDeals;
   }
+
   /**
    * Gets the speechtype by current offer
    * @return SpeechType
@@ -577,6 +531,7 @@ public class DiplomaticTrade {
           Integer.valueOf(1)));
     }
   }
+
   /**
    * Generate credit gift
    * @param giver player who is giving the gift
@@ -600,6 +555,7 @@ public class DiplomaticTrade {
       }
     }
   }
+
   /**
    * Generate tech demand or artifact demand or money demand
    * @param agreePlayer Who is need to agree with trade
@@ -635,6 +591,7 @@ public class DiplomaticTrade {
     }
     secondOffer = new NegotiationList();
   }
+
   /**
    * Generate Map trade between two players.
    * @param tradeType Choices are TRADE, BUY and SELL
@@ -860,6 +817,7 @@ public class DiplomaticTrade {
     }
     return bestPlanet;
   }
+
   /**
    * Generate peace offer depending on military power difference
    * and war fatigue
@@ -1083,6 +1041,7 @@ public class DiplomaticTrade {
       }
     }
   }
+
   /**
    * Generate first offer depending on AI's attitude.
    */
@@ -1190,6 +1149,7 @@ public class DiplomaticTrade {
     }
     return -1;
   }
+
   /**
    * Offer by aggressive attitude.
    * This makes war quite easily and can make demands.
@@ -1388,9 +1348,6 @@ public class DiplomaticTrade {
       }
     }
   }
-  /**
-   * Generate diplomatic trade offer between two players
-   */
 
   /**
    * Offer by diplomatic attitude.
@@ -1593,6 +1550,7 @@ public class DiplomaticTrade {
       }
     }
   }
+
   /**
    * Offer by scientific attitude.
    * Tries to focus trading or buying the tech
@@ -1803,6 +1761,7 @@ public class DiplomaticTrade {
       }
     }
   }
+
   /**
    * Offer by Militaristic attitude.
    * This makes war quite easily and can make demands if
@@ -1901,6 +1860,7 @@ public class DiplomaticTrade {
       }
     }
   }
+
   /**
    * Very basic offer by logical attitude.
    * This makes war only if power difference goes too big.
@@ -1988,6 +1948,7 @@ public class DiplomaticTrade {
       }
     }
   }
+
   /**
    * Offer by peaceful attitude.
    * This makes war only if power difference goes too big.
@@ -2078,6 +2039,7 @@ public class DiplomaticTrade {
       }
     }
   }
+
   /**
    * Generate diplomatic trade offer between two players
    */
@@ -2223,6 +2185,7 @@ public class DiplomaticTrade {
     }
     return value;
   }
+
   /**
    * Is offer good for both. This assumes that first one is making the offer
    * and is okay with it. So it only checks that second one likes it.
@@ -2402,6 +2365,7 @@ public class DiplomaticTrade {
     }
     return difference;
   }
+
   /**
    * Is offer good for both. This assumes that first one is making the offer
    * and is okay with it. So it only checks that second one likes it.
@@ -2435,6 +2399,7 @@ public class DiplomaticTrade {
     }
     return planets.toArray(new Planet[planets.size()]);
   }
+
   /**
    * Get war chance for getting decline for offer
    * @param type What was the original SpeechType
@@ -2671,6 +2636,7 @@ public class DiplomaticTrade {
       info.getMsgList().addUpcomingMessage(msg);
     }
   }
+
   /**
    * Do trading for one player
    * @param offerList Trade goods aka offering list
@@ -2984,6 +2950,7 @@ public class DiplomaticTrade {
           DiplomacyBonusType.GIVEN_VALUABLE_FREE, info.getRace());
     }
   }
+
   /**
    * Has planet traded?
    * @return True if planet has traded.
@@ -2991,6 +2958,7 @@ public class DiplomaticTrade {
   public boolean isPlanetTraded() {
     return planetTraded;
   }
+
   /**
    * Trade has been gift?
    * @return True if trade has been gift.
@@ -2998,65 +2966,63 @@ public class DiplomaticTrade {
   public boolean isGiftTraded() {
     return giftTrade;
   }
+
   /**
-   * Generate Fleet list containing all fleets from both players.
+   * Generate Fleet list containing all visible fleets from both players.
    */
   private void generateFleetList() {
-    fleetListForFirst = new ArrayList<>();
-    fleetListForSecond = new ArrayList<>();
     PlayerInfo info = starMap.getPlayerByIndex(first);
     PlayerInfo viewer = starMap.getPlayerByIndex(second);
-    int size = info.getFleets().getNumberOfFleets();
-    for (int i = 0; i < size; i++) {
-      Fleet fleet = info.getFleets().getByIndex(i);
-      FleetVisibility visiblity = new FleetVisibility(viewer, fleet, first);
-      if (visiblity.isFleetVisible()) {
-        if (fleet.isPrivateerFleet() && visiblity.isRecognized()) {
-          fleetListForFirst.add(fleet);
-        } else if (!fleet.isPrivateerFleet()) {
-          fleetListForFirst.add(fleet);
-        }
-      }
-    }
+    fleetListForFirst = generateFleetList(info, viewer);
+
     info = starMap.getPlayerByIndex(second);
     viewer = starMap.getPlayerByIndex(first);
-    size = info.getFleets().getNumberOfFleets();
+    fleetListForSecond = generateFleetList(info, viewer);
+  }
+
+  /**
+   * Generate List containing all fleets of owner, visible by viewer.
+   * @param owner Owner of fleets
+   * @param viewer Player to check fleet visibility for
+   * @return ArrayList<Fleet> of owner fleets visible to viewer
+   */
+  private ArrayList<Fleet> generateFleetList(final PlayerInfo owner,
+      final PlayerInfo viewer) {
+    var list = new ArrayList<Fleet>();
+    final var size = owner.getFleets().getNumberOfFleets();
     for (int i = 0; i < size; i++) {
-      Fleet fleet = info.getFleets().getByIndex(i);
+      Fleet fleet = owner.getFleets().getByIndex(i);
       FleetVisibility visiblity = new FleetVisibility(viewer, fleet, second);
       if (visiblity.isFleetVisible()) {
         if (fleet.isPrivateerFleet() && visiblity.isRecognized()) {
-          fleetListForSecond.add(fleet);
+          list.add(fleet);
         }  else if (!fleet.isPrivateerFleet()) {
-          fleetListForSecond.add(fleet);
+          list.add(fleet);
         }
       }
     }
+
+    return list;
   }
+
   /**
    * Generate Tech list containing techs whichs are tradeable.
    */
   private void generateTechList() {
     techListForFirst = new ArrayList<>();
     techListForSecond = new ArrayList<>();
-    for (int type = 0; type < 6; type++) {
+    for (var techType : TechType.values()) {
       Tech[] tradeTechs = starMap.getPlayerByIndex(second)
-          .getTechList().getListForType(TechType
-              .getTypeByIndex(type));
+          .getTechList().getListForType(techType);
       Tech[] ownTechs = starMap.getPlayerByIndex(first)
-          .getTechList().getListForType(TechType
-              .getTypeByIndex(type));
+          .getTechList().getListForType(techType);
+
       Tech[] techs = TechList.getTechDifference(tradeTechs, ownTechs);
       for (Tech tech : techs) {
         techListForFirst.add(tech);
       }
-      tradeTechs = starMap.getPlayerByIndex(first)
-          .getTechList().getListForType(TechType
-              .getTypeByIndex(type));
-      ownTechs = starMap.getPlayerByIndex(second)
-          .getTechList().getListForType(TechType
-              .getTypeByIndex(type));
-      techs = TechList.getTechDifference(tradeTechs, ownTechs);
+
+      techs = TechList.getTechDifference(ownTechs, tradeTechs);
       for (Tech tech : techs) {
         techListForSecond.add(tech);
       }

--- a/src/main/java/org/openRealmOfStars/player/diplomacy/negotiation/NegotiationList.java
+++ b/src/main/java/org/openRealmOfStars/player/diplomacy/negotiation/NegotiationList.java
@@ -22,16 +22,12 @@ import java.util.ArrayList;
 import org.openRealmOfStars.player.PlayerInfo;
 
 /**
-*
-* Negotiation list containing multiple offers. This is not saved for
-* saved games. Negotations needs to be handled immediately.
-*
-*/
+ * Negotiation list containing multiple offers. This is not saved for
+ * saved games. Negotations needs to be handled immediately.
+ */
 public class NegotiationList {
 
-  /**
-   * List containing NegotiationOffers
-   */
+  /** List containing NegotiationOffers */
   private ArrayList<NegotiationOffer> list;
 
   /**

--- a/src/main/java/org/openRealmOfStars/player/diplomacy/negotiation/NegotiationOffer.java
+++ b/src/main/java/org/openRealmOfStars/player/diplomacy/negotiation/NegotiationOffer.java
@@ -26,25 +26,18 @@ import org.openRealmOfStars.starMap.planet.construction.Building;
 import org.openRealmOfStars.starMap.planet.construction.BuildingFactory;
 
 /**
-*
-* Negotiation offer for single object. This is not saved for
-* saved games. Negotations needs to be handled immediately.
-*
-*/
+ * Negotiation offer for single object. This is not saved for
+ * saved games. Negotations needs to be handled immediately.
+ */
 public class NegotiationOffer {
-  /**
-   * Negotiation type
-   */
+  /** Negotiation type */
   private NegotiationType negotiationType;
-  /**
-   * Offer object. This can be fleet, planet
-   */
+  /** Offer object. This can be fleet, planet */
   private Object offerObject;
 
-  /**
-   * Map Value. Used for valuing the map.
-   */
+  /** Map Value. Used for valuing the map. */
   private int mapValue;
+
   /**
    * Constructor for Negotiation offer
    * @param type Negotiation Type
@@ -283,6 +276,7 @@ public class NegotiationOffer {
     }
     return 0;
   }
+
   /**
    * Get Negotiation type
    * @return Negotiation type

--- a/src/main/java/org/openRealmOfStars/player/diplomacy/negotiation/NegotiationType.java
+++ b/src/main/java/org/openRealmOfStars/player/diplomacy/negotiation/NegotiationType.java
@@ -18,86 +18,46 @@ package org.openRealmOfStars.player.diplomacy.negotiation;
  */
 
 /**
-*
-* Negotiation type
-*
-*/
+ * Negotiation type
+ */
 public enum NegotiationType {
-  /**
-   * Credit offering
-   */
+  /** Credit offering */
   CREDIT,
-  /**
-   * Planet offering
-   */
+  /** Planet offering */
   PLANET,
-  /**
-   * Fleet offering
-   */
+  /** Fleet offering */
   FLEET,
-  /**
-   * Tech offering
-   */
+  /** Tech offering */
   TECH,
-  /**
-   * Peace offering
-   */
+  /** Peace offering */
   PEACE,
-  /**
-   * Trade alliance offering
-   */
+  /** Trade alliance offering */
   TRADE_ALLIANCE,
-  /**
-   * Alliance offering
-   */
+  /** Alliance offering */
   ALLIANCE,
-  /**
-   * Map offering
-   */
+  /** Map offering */
   MAP,
-  /**
-   * Captured diplomat offering
-   */
+  /** Captured diplomat offering */
   DIPLOMAT,
-  /**
-   * War offering or threat
-   */
+  /** War offering or threat */
   WAR,
-  /**
-   * Recall fleet due border crossing
-   */
+  /** Recall fleet due border crossing */
   RECALL_FLEET,
-  /**
-   * Defensive pact offering
-   */
+  /** Defensive pact offering */
   DEFENSIVE_PACT,
-  /**
-   * Spy trade offering
-   */
+  /** Spy trade offering */
   SPY_TRADE,
-  /**
-   * Trade embargo offering
-   */
+  /** Trade embargo offering */
   TRADE_EMBARGO,
-  /**
-   * Map containing only realm's planets
-   */
+  /** Map containing only realm's planets */
   MAP_PLANETS,
-  /**
-   * Promise to vote yes in next important voting.
-   */
+  /** Promise to vote yes in next important voting. */
   PROMISE_VOTE_YES,
-  /**
-   * Promise to vote no in next important voting.
-   */
+  /** Promise to vote no in next important voting. */
   PROMISE_VOTE_NO,
-  /**
-   * Discovered ancient artifact.
-   */
+  /** Discovered ancient artifact. */
   DISCOVERED_ARTIFACT,
-  /**
-   * Ask protection from space pirates.
-   */
+  /** Ask protection from space pirates. */
   ASK_PROTECTION;
 
 }

--- a/src/main/java/org/openRealmOfStars/player/diplomacy/speeches/SpeechLine.java
+++ b/src/main/java/org/openRealmOfStars/player/diplomacy/speeches/SpeechLine.java
@@ -18,20 +18,13 @@ package org.openRealmOfStars.player.diplomacy.speeches;
  */
 
 /**
-*
-* Speech lines
-*
-*/
+ * Speech lines
+ */
 public class SpeechLine {
 
-  /**
-   * Speech type
-   */
+  /** Speech type */
   private SpeechType type;
-
-  /**
-   * Actual line in text
-   */
+  /** Actual line in text */
   private String line;
 
   /**
@@ -43,6 +36,7 @@ public class SpeechLine {
     type = speechType;
     line = text;
   }
+
   /**
    * Get line type
    * @return Speech type

--- a/src/main/java/org/openRealmOfStars/player/diplomacy/speeches/SpeechType.java
+++ b/src/main/java/org/openRealmOfStars/player/diplomacy/speeches/SpeechType.java
@@ -18,125 +18,65 @@ package org.openRealmOfStars.player.diplomacy.speeches;
  */
 
 /**
-*
-* Speech types for lines and answers
-*
-*/
+ * Speech types for lines and answers
+ */
 public enum SpeechType {
-  /**
-   * LINE: Trade offer a fair one made sincerely
-   */
+  /** LINE: Trade offer a fair one made sincerely */
   TRADE,
-  /**
-   * LINE: Trade offer made with demand
-   */
+  /** LINE: Trade offer made with demand */
   DEMAND,
-  /**
-   * LINE: Make war between
-   */
+  /** LINE: Make war between */
   MAKE_WAR,
-  /**
-   * LINE: Offer trade alliance
-   */
+  /** LINE: Offer trade alliance */
   TRADE_ALLIANCE,
-  /**
-   * LINE: Offer alliance
-   */
+  /** LINE: Offer alliance */
   ALLIANCE,
-  /**
-   * Answer: Agree to offer
-   */
+  /** Answer: Agree to offer */
   AGREE,
-  /**
-   * Answer: Decline offer politely
-   */
+  /** Answer: Decline offer politely */
   DECLINE,
-  /**
-   * Answer: Decline offer with anger
-   */
+  /** Answer: Decline offer with anger */
   DECLINE_ANGER,
-  /**
-   * Answer: Decline offer with war
-   */
+  /** Answer: Decline offer with war */
   DECLINE_WAR,
-  /**
-   * Neutral greeting
-   */
+  /** Neutral greeting */
   NEUTRAL_GREET,
-  /**
-   * Dislike greeting
-   */
+  /** Dislike greeting */
   DISLIKE_GREET,
-  /**
-   * Hate greeting
-   */
+  /** Hate greeting */
   HATE_GREET,
-  /**
-   * Like greeting
-   */
+  /** Like greeting */
   LIKE_GREET,
-  /**
-   * Friends greeting
-   */
+  /** Friends greeting */
   FRIENDS_GREET,
-  /**
-   * Peace offer
-   */
+  /** Peace offer */
   PEACE_OFFER,
-  /**
-   * Respond for insult
-   */
+  /** Respond for insult */
   INSULT_RESPOND,
-  /**
-   * Offer has been rejected
-   */
+  /** Offer has been rejected */
   OFFER_REJECTED,
-  /**
-   * Offer has been accepted
-   */
+  /** Offer has been accepted */
   OFFER_ACCEPTED,
-  /**
-   * Demand move fleet
-   */
+  /** Demand move fleet */
   ASK_MOVE_FLEET,
-  /**
-   * Agree to move fleet
-   */
+  /** Agree to move fleet */
   MOVE_FLEET,
-  /**
-   * AI notices that there weren't really anything for trade.
-   */
+  /** AI notices that there weren't really anything for trade. */
   NOTHING_TO_TRADE,
-  /**
-   * LINE: Offer defensive pact
-   */
+  /** LINE: Offer defensive pact */
   DEFESIVE_PACT,
-  /**
-   * Demand move espionage fleet
-   */
+  /** Demand move espionage fleet */
   ASK_MOVE_SPY,
-  /**
-   * Offer espionage trade for 20 star years.
-   */
+  /** Offer espionage trade for 20 star years. */
   OFFER_SPY_TRADE,
-  /**
-   * Offer trade embargo for 20 star years
-   */
+  /** Offer trade embargo for 20 star years */
   TRADE_EMBARGO,
-  /**
-   * Realm choice for embargo, not real speech line
-   */
+  /** Realm choice for embargo, not real speech line */
   TRADE_EMBARGO_REALM_CHOICE,
-  /**
-   * Fleets have crossed borders too many times, declared the war.
-   */
+  /** Fleets have crossed borders too many times, declared the war. */
   BORDER_WARS,
-  /**
-   * Space pirates could ask protection or realm could pay for protection
-   */
+  /** Space pirates could ask protection or realm could pay for protection */
   ASK_PROTECTION;
-
-
 
   /**
    * Get Speech Type as a string.


### PR DESCRIPTION
Reformat Diplomacy code to fix and reduce verbosity of comments, remove redundant fields and sort remaining fields.
Also remove some duplicate code.