### PR TITLE
Remove hardcoded race diplomacy bonuses

### DIFF
--- a/src/main/java/org/openRealmOfStars/player/diplomacy/DiplomacyBonus.java
+++ b/src/main/java/org/openRealmOfStars/player/diplomacy/DiplomacyBonus.java
@@ -44,425 +44,219 @@ public class DiplomacyBonus {
    */
   public DiplomacyBonus(final DiplomacyBonusType bonusType,
       final SpaceRace race) {
-   type = bonusType;
-   onlyOne = false;
-   switch (type) {
-     case BORDER_CROSSED: {
-       if (race == SpaceRace.SPORKS || race == SpaceRace.SCAURIANS) {
-         bonusValue = -2;
-         bonusLasting = 15;
-       } else if (race == SpaceRace.MECHIONS) {
-         bonusValue = -3;
-         bonusLasting = 15;
-       } else if (race == SpaceRace.SMAUGIRIANS) {
-         bonusValue = -1;
-         bonusLasting = 20;
-       } else {
-         bonusValue = -3;
-         bonusLasting = 20;
-       }
-       break;
-     }
-     case GIVEN_VALUABLE_FREE: {
-       if (race == SpaceRace.HUMAN || race == SpaceRace.SCAURIANS) {
-         bonusValue = 3;
-         bonusLasting = 50;
-       } else {
-         bonusValue = 2;
-         bonusLasting = 50;
-       }
-       break;
-     }
-     case IN_ALLIANCE: {
-       onlyOne = true;
-       if (race == SpaceRace.GREYANS) {
-         bonusValue = 30;
-         bonusLasting = 255;
-       } else {
-         bonusValue = 25;
-         bonusLasting = 255;
-       }
-       break;
-     }
-     case IN_TRADE_ALLIANCE: {
-       onlyOne = true;
-       if (race == SpaceRace.GREYANS || race == SpaceRace.SCAURIANS) {
-         bonusValue = 18;
-         bonusLasting = 255;
-       } else {
-         bonusValue = 12;
-         bonusLasting = 255;
-       }
-       break;
-     }
-     case LONG_PEACE: {
-       onlyOne = true;
-       if (race == SpaceRace.SPORKS || race == SpaceRace.REBORGIANS) {
-         bonusValue = 1;
-         bonusLasting = 1;
-       } else if (race == SpaceRace.MOTHOIDS) {
-         bonusValue = 8;
-         bonusLasting = 1;
-       } else if (race == SpaceRace.SCAURIANS) {
-         bonusValue = 6;
-         bonusLasting = 1;
-       } else {
-         bonusValue = 5;
-         bonusLasting = 1;
-       }
-       break;
-     }
-     case DIPLOMATIC_TRADE: {
-       if (race == SpaceRace.HUMAN || race == SpaceRace.SCAURIANS) {
-         bonusValue = 5;
-         bonusLasting = 110;
-       } else if (race == SpaceRace.REBORGIANS) {
-         bonusValue = 3;
-         bonusLasting = 100;
-       } else {
-         bonusValue = 4;
-         bonusLasting = 100;
-       }
-       break;
-     }
-     case IN_WAR: {
-       onlyOne = true;
-       if (race == SpaceRace.GREYANS || race == SpaceRace.ALTEIRIANS) {
-         bonusValue = -40;
-         bonusLasting = 255;
-       } else {
-         bonusValue = -30;
-         bonusLasting = 255;
-       }
-       break;
-     }
-     case WAR_DECLARTION: {
-       if (race == SpaceRace.SPORKS) {
-         bonusValue = -2;
-         bonusLasting = 100;
-       } else if (race == SpaceRace.REBORGIANS) {
-         bonusValue = -4;
-         bonusLasting = 100;
-       } else {
-         bonusValue = -8;
-         bonusLasting = 150;
-       }
-       break;
-     }
-     case MADE_DEMAND: {
-       if (race == SpaceRace.SPORKS) {
-         bonusValue = -10;
-         bonusLasting = 150;
-       } else {
-         bonusValue = -5;
-         bonusLasting = 80;
-       }
-       break;
-     }
-     case INSULT: {
-       if (race == SpaceRace.SPORKS || race == SpaceRace.CHIRALOIDS) {
-         bonusValue = -2;
-         bonusLasting = 60;
-       } else if (race == SpaceRace.MECHIONS || race == SpaceRace.REBORGIANS
-           || race == SpaceRace.SYNTHDROIDS) {
-         bonusValue = -1;
-         bonusLasting = 20;
-       } else {
-         bonusValue = -3;
-         bonusLasting = 70;
-       }
-       break;
-     }
-     case SAME_RACE: {
-       onlyOne = true;
-       if (race == SpaceRace.MECHIONS || race == SpaceRace.TEUTHIDAES) {
-         bonusValue = -3;
-         bonusLasting = 255;
-       } else if (race == SpaceRace.SPORKS) {
-         bonusValue = 2;
-         bonusLasting = 255;
-       } else {
-         bonusValue = 5;
-         bonusLasting = 255;
-       }
-       break;
-     }
-     case SIMILAR_GOVERNMENT: {
-       onlyOne = true;
-       bonusValue = 2;
-       bonusLasting = 255;
-       break;
-     }
-     case SAME_GOVERNMENT: {
-       onlyOne = true;
-       bonusValue = 3;
-       bonusLasting = 255;
-       break;
-     }
-     case SIMILAR_GOVERNMENT_DIFFERENT_GROUP: {
-       onlyOne = true;
-       bonusValue = 1;
-       bonusLasting = 255;
-       break;
-     }
-     case DIFFERENT_GOVERNMENT: {
-       onlyOne = true;
-       bonusValue = -2;
-       bonusLasting = 255;
-       break;
-     }
-     case NUKED: {
-       if (race == SpaceRace.CENTAURS || race == SpaceRace.HOMARIANS) {
-         bonusValue = -8;
-         bonusLasting = 120;
-       } else if (race == SpaceRace.HUMAN || race == SpaceRace.TEUTHIDAES) {
-         bonusValue = -6;
-         bonusLasting = 120;
-       } else if (race == SpaceRace.SPORKS || race == SpaceRace.SCAURIANS
-           || race == SpaceRace.SYNTHDROIDS) {
-         bonusValue = -4;
-         bonusLasting = 100;
-       } else if (race == SpaceRace.MECHIONS) {
-         bonusValue = -3;
-         bonusLasting = 80;
-       } else if (race == SpaceRace.CHIRALOIDS) {
-         bonusValue = 2;
-         bonusLasting = 40;
-       } else {
-         bonusValue = -5;
-         bonusLasting = 100;
-       }
-       break;
-     }
-     case NOTHING_TO_TRADE: {
-       onlyOne = true;
-       bonusValue = 0;
-       bonusLasting = 10;
-       break;
-     }
-     case IN_DEFENSIVE_PACT: {
-       onlyOne = true;
-       if (race == SpaceRace.HUMAN || race == SpaceRace.HOMARIANS
-           || race == SpaceRace.LITHORIANS) {
-         bonusValue = 30;
-         bonusLasting = 255;
-       } else if (race == SpaceRace.TEUTHIDAES || race == SpaceRace.SPORKS) {
-         bonusValue = 20;
-         bonusLasting = 255;
-       } else {
-         bonusValue = 25;
-         bonusLasting = 255;
-       }
-       break;
-     }
-     case ESPIONAGE_BORDER_CROSS: {
-       if (race == SpaceRace.SPORKS || race == SpaceRace.TEUTHIDAES
-           || race == SpaceRace.CHIRALOIDS) {
-         bonusValue = -2;
-         bonusLasting = 20;
-       } else if (race == SpaceRace.MECHIONS) {
-         bonusValue = -6;
-         bonusLasting = 20;
-       } else if (race == SpaceRace.SYNTHDROIDS) {
-         bonusValue = -5;
-         bonusLasting = 25;
-       } else {
-         bonusValue = -4;
-         bonusLasting = 30;
-       }
-       break;
-     }
-     case SPY_TRADE: {
-       if (race == SpaceRace.TEUTHIDAES) {
-         bonusValue = 15;
-       } else if (race == SpaceRace.SPORKS) {
-         bonusValue = 13;
-       } else if (race == SpaceRace.CHIRALOIDS) {
-         bonusValue = 12;
-       } else if (race == SpaceRace.HOMARIANS) {
-         bonusValue = 8;
-       } else if (race == SpaceRace.MECHIONS) {
-         bonusValue = 8;
-       } else {
-         bonusValue = 10;
-       }
-       bonusLasting = 20;
-       onlyOne = true;
-       break;
-     }
-     case DIPLOMACY_BONUS: {
-       bonusValue = race.getDiplomacyBonus();
-       bonusLasting = 255;
-       break;
-     }
-     case TRADE_FLEET: {
-       if (race == SpaceRace.SCAURIANS) {
-         bonusValue = 6;
-       } else if (race == SpaceRace.HUMAN) {
-         bonusValue = 4;
-       } else {
-         bonusValue = 3;
-       }
-       bonusLasting = 255;
-       onlyOne = true;
-       break;
-     }
-     case BOARD_PLAYER: {
-       onlyOne = true;
-       bonusValue = 0;
-       bonusLasting = 255;
-       break;
-     }
-     case EMBARGO: {
-       onlyOne = true;
-       if (race == SpaceRace.SCAURIANS
-           || race == SpaceRace.SPORKS
-           || race == SpaceRace.CHIRALOIDS) {
-         bonusValue = -8;
-         bonusLasting = 20;
-       } else {
-         bonusValue = -5;
-         bonusLasting = 20;
-       }
-       break;
-     }
-     case LIKED_EMBARGO: {
-       if (race == SpaceRace.SCAURIANS
-           || race == SpaceRace.HUMAN
-           || race == SpaceRace.GREYANS
-           || race == SpaceRace.CENTAURS) {
-         bonusValue = 4;
-         bonusLasting = 60;
-       } else {
-         bonusValue = 2;
-         bonusLasting = 60;
-       }
-       break;
-     }
-     case DISLIKED_EMBARGO: {
-       if (race == SpaceRace.SCAURIANS
-           || race == SpaceRace.HUMAN
-           || race == SpaceRace.GREYANS
-           || race == SpaceRace.CENTAURS) {
-         bonusValue = -4;
-         bonusLasting = 60;
-       } else {
-         bonusValue = -2;
-         bonusLasting = 60;
-       }
-       break;
-     }
-     case REALM_LOST: {
-       onlyOne = true;
-       bonusValue = 0;
-       bonusLasting = 255;
-       break;
-     }
-     case OLYMPICS: {
-       if (race == SpaceRace.HUMAN || race == SpaceRace.SPORKS) {
-         bonusValue = 10;
-         bonusLasting = 110;
-       } else if (race == SpaceRace.MECHIONS
-           || race == SpaceRace.SYNTHDROIDS) {
-         bonusValue = 5;
-         bonusLasting = 90;
-       } else {
-         bonusValue = 7;
-         bonusLasting = 100;
-       }
-       break;
-     }
-     case DNS_OLYMPICS: {
-       if (race == SpaceRace.SPORKS) {
-         bonusValue = -10;
-         bonusLasting = 110;
-       } else if (race == SpaceRace.MECHIONS
-           || race == SpaceRace.SYNTHDROIDS) {
-         bonusValue = -5;
-         bonusLasting = 90;
-       } else {
-         bonusValue = -7;
-         bonusLasting = 100;
-       }
-       break;
-     }
-     case OLYMPICS_EMBARGO: {
-       if (race == SpaceRace.HUMAN) {
-         bonusValue = 8;
-         bonusLasting = 110;
-       } else if (race == SpaceRace.MECHIONS
-           || race == SpaceRace.SYNTHDROIDS) {
-         bonusValue = 4;
-         bonusLasting = 90;
-       } else {
-         bonusValue = 6;
-         bonusLasting = 100;
-       }
-       break;
-     }
-     case PROMISED_VOTE_YES: {
-       bonusValue = 3;
-       bonusLasting = 40;
-       break;
-     }
-     case PROMISED_VOTE_NO: {
-       bonusValue = 3;
-       bonusLasting = 40;
-       break;
-     }
-     case PROMISE_KEPT: {
-       if (race == SpaceRace.HUMAN) {
-         bonusValue = 10;
-         bonusLasting = 100;
-       } else if (race == SpaceRace.MECHIONS) {
-         bonusValue = 6;
-         bonusLasting = 100;
-       } else {
-         bonusValue = 8;
-         bonusLasting = 100;
-       }
-       break;
-     }
-     case PROMISE_BROKEN: {
-       if (race == SpaceRace.HUMAN) {
-         bonusValue = -10;
-         bonusLasting = 100;
-       } else if (race == SpaceRace.MECHIONS) {
-         bonusValue = -6;
-         bonusLasting = 100;
-       } else if (race == SpaceRace.SPORKS) {
-         bonusValue = -4;
-         bonusLasting = 100;
-       } else {
-         bonusValue = -8;
-         bonusLasting = 100;
-       }
-       break;
-     }
-     case WAR_DECLARATION_AGAINST_US: {
-       bonusValue = -12;
-       bonusLasting = 255;
-       break;
-     }
-     case FALSE_FLAG: {
-       bonusValue = -4;
-       bonusLasting = 60;
-       break;
-     }
-     case FREED_CONVICT: {
-       bonusValue = -2;
-       bonusLasting = 60;
-       break;
-     }
-     case PROMISED_PROTECTION: {
-       bonusValue = 3;
-       bonusLasting = 5;
-       break;
-     }
-     default: {
-       throw new IllegalArgumentException("Unknown bonus type!!");
-     }
-   }
+    type = bonusType;
+    onlyOne = false;
+    switch (type) {
+      case BORDER_CROSSED: {
+        bonusValue = -3;
+        bonusLasting = 20;
+        break;
+      }
+      case GIVEN_VALUABLE_FREE: {
+        bonusValue = 2;
+        bonusLasting = 50;
+        break;
+      }
+      case IN_ALLIANCE: {
+        onlyOne = true;
+        bonusValue = 25;
+        bonusLasting = 255;
+        break;
+      }
+      case IN_TRADE_ALLIANCE: {
+        onlyOne = true;
+        bonusValue = 12;
+        bonusLasting = 255;
+        break;
+      }
+      case LONG_PEACE: {
+        onlyOne = true;
+        bonusValue = 5;
+        bonusLasting = 1;
+        break;
+      }
+      case DIPLOMATIC_TRADE: {
+        bonusValue = 4;
+        bonusLasting = 100;
+        break;
+      }
+      case IN_WAR: {
+        onlyOne = true;
+        bonusValue = -30;
+        bonusLasting = 255;
+        break;
+      }
+      case WAR_DECLARTION: {
+        bonusValue = -8;
+        bonusLasting = 150;
+        break;
+      }
+      case MADE_DEMAND: {
+        bonusValue = -5;
+        bonusLasting = 80;
+        break;
+      }
+      case INSULT: {
+        bonusValue = -3;
+        bonusLasting = 70;
+        break;
+      }
+      case SAME_RACE: {
+        onlyOne = true;
+        bonusValue = 5;
+        bonusLasting = 255;
+        break;
+      }
+      case SIMILAR_GOVERNMENT: {
+        onlyOne = true;
+        bonusValue = 2;
+        bonusLasting = 255;
+        break;
+      }
+      case SAME_GOVERNMENT: {
+        onlyOne = true;
+        bonusValue = 3;
+        bonusLasting = 255;
+        break;
+      }
+      case SIMILAR_GOVERNMENT_DIFFERENT_GROUP: {
+        onlyOne = true;
+        bonusValue = 1;
+        bonusLasting = 255;
+        break;
+      }
+      case DIFFERENT_GOVERNMENT: {
+        onlyOne = true;
+        bonusValue = -2;
+        bonusLasting = 255;
+        break;
+      }
+      case NUKED: {
+        bonusValue = -5;
+        bonusLasting = 100;
+        break;
+      }
+      case NOTHING_TO_TRADE: {
+        onlyOne = true;
+        bonusValue = 0;
+        bonusLasting = 10;
+        break;
+      }
+      case IN_DEFENSIVE_PACT: {
+        onlyOne = true;
+        bonusValue = 25;
+        bonusLasting = 255;
+        break;
+      }
+      case ESPIONAGE_BORDER_CROSS: {
+        bonusValue = -4;
+        bonusLasting = 30;
+        break;
+      }
+      case SPY_TRADE: {
+        bonusValue = 10;
+        bonusLasting = 20;
+        onlyOne = true;
+        break;
+      }
+      case DIPLOMACY_BONUS: {
+        bonusValue = race.getDiplomacyBonus();
+        bonusLasting = 255;
+        break;
+      }
+      case TRADE_FLEET: {
+        bonusValue = 3;
+        bonusLasting = 255;
+        onlyOne = true;
+        break;
+      }
+      case BOARD_PLAYER: {
+        onlyOne = true;
+        bonusValue = 0;
+        bonusLasting = 255;
+        break;
+      }
+      case EMBARGO: {
+        onlyOne = true;
+        bonusValue = -5;
+        bonusLasting = 20;
+        break;
+      }
+      case LIKED_EMBARGO: {
+        bonusValue = 2;
+        bonusLasting = 60;
+        break;
+      }
+      case DISLIKED_EMBARGO: {
+        bonusValue = -2;
+        bonusLasting = 60;
+        break;
+      }
+      case REALM_LOST: {
+        onlyOne = true;
+        bonusValue = 0;
+        bonusLasting = 255;
+        break;
+      }
+      case OLYMPICS: {
+        bonusValue = 7;
+        bonusLasting = 100;
+        break;
+      }
+      case DNS_OLYMPICS: {
+        bonusValue = -7;
+        bonusLasting = 100;
+        break;
+      }
+      case OLYMPICS_EMBARGO: {
+        bonusValue = 6;
+        bonusLasting = 100;
+        break;
+      }
+      case PROMISED_VOTE_YES: {
+        bonusValue = 3;
+        bonusLasting = 40;
+        break;
+      }
+      case PROMISED_VOTE_NO: {
+        bonusValue = 3;
+        bonusLasting = 40;
+        break;
+      }
+      case PROMISE_KEPT: {
+        bonusValue = 8;
+        bonusLasting = 100;
+        break;
+      }
+      case PROMISE_BROKEN: {
+        bonusValue = -8;
+        bonusLasting = 100;
+        break;
+      }
+      case WAR_DECLARATION_AGAINST_US: {
+        bonusValue = -12;
+        bonusLasting = 255;
+        break;
+      }
+      case FALSE_FLAG: {
+        bonusValue = -4;
+        bonusLasting = 60;
+        break;
+      }
+      case FREED_CONVICT: {
+        bonusValue = -2;
+        bonusLasting = 60;
+        break;
+      }
+      case PROMISED_PROTECTION: {
+        bonusValue = 3;
+        bonusLasting = 5;
+        break;
+      }
+      default: {
+        throw new IllegalArgumentException("Unknown bonus type!!");
+      }
+    }
   }
 
   /**
@@ -502,6 +296,7 @@ public class DiplomacyBonus {
   public boolean isOnlyOne() {
     return onlyOne;
   }
+
   /**
    * Set Diplomacy Bonus value.
    * @param bonusValue to set
@@ -544,6 +339,5 @@ public class DiplomacyBonus {
   public String toString() {
     return type.name() + " Value: " + bonusValue + " Lasting: " + bonusLasting;
   }
-
 
 }

--- a/src/main/java/org/openRealmOfStars/player/diplomacy/DiplomacyBonus.java
+++ b/src/main/java/org/openRealmOfStars/player/diplomacy/DiplomacyBonus.java
@@ -63,19 +63,6 @@ public class DiplomacyBonus {
        }
        break;
      }
-     case DIPLOMAT_CAPTURED: {
-       if (race == SpaceRace.SPORKS) {
-         bonusValue = -3;
-         bonusLasting = 200;
-       } else if (race == SpaceRace.CENTAURS) {
-         bonusValue = -8;
-         bonusLasting = 200;
-       } else {
-         bonusValue = -5;
-         bonusLasting = 200;
-       }
-       break;
-     }
      case GIVEN_VALUABLE_FREE: {
        if (race == SpaceRace.HUMAN || race == SpaceRace.SCAURIANS) {
          bonusValue = 3;

--- a/src/main/java/org/openRealmOfStars/player/diplomacy/DiplomacyBonusType.java
+++ b/src/main/java/org/openRealmOfStars/player/diplomacy/DiplomacyBonusType.java
@@ -38,10 +38,6 @@ public enum DiplomacyBonusType {
    */
   IN_ALLIANCE,
   /**
-   * Other player has captured a diplomat.
-   */
-  DIPLOMAT_CAPTURED,
-  /**
    * Border has been crossed with any ship where there is no alliance.
    */
   BORDER_CROSSED,
@@ -194,49 +190,13 @@ public enum DiplomacyBonusType {
    * @return int
    */
   public int getIndex() {
-    switch (this) {
-      case IN_WAR: return 0;
-      case WAR_DECLARTION: return 1;
-      case IN_TRADE_ALLIANCE: return 2;
-      case IN_ALLIANCE: return 3;
-      case DIPLOMAT_CAPTURED: return 4;
-      case BORDER_CROSSED: return 5;
-      case GIVEN_VALUABLE_FREE: return 6;
-      case MADE_DEMAND: return 7;
-      case DIPLOMATIC_TRADE: return 8;
-      case SAME_RACE: return 9;
-      case LONG_PEACE: return 10;
-      case INSULT: return 11;
-      case NUKED: return 12;
-      case NOTHING_TO_TRADE: return 13;
-      case IN_DEFENSIVE_PACT: return 14;
-      case ESPIONAGE_BORDER_CROSS: return 15;
-      case SPY_TRADE: return 16;
-      case DIPLOMACY_BONUS: return 17;
-      case TRADE_FLEET: return 18;
-      case BOARD_PLAYER: return 19;
-      case EMBARGO: return 20;
-      case LIKED_EMBARGO: return 21;
-      case DISLIKED_EMBARGO: return 22;
-      case REALM_LOST: return 23;
-      case OLYMPICS: return 24;
-      case DNS_OLYMPICS: return 25;
-      case OLYMPICS_EMBARGO: return 26;
-      case PROMISED_VOTE_YES: return 27;
-      case PROMISED_VOTE_NO: return 28;
-      case PROMISE_KEPT: return 29;
-      case PROMISE_BROKEN: return 30;
-      case WAR_DECLARATION_AGAINST_US: return 31;
-      case FALSE_FLAG: return 32;
-      case FREED_CONVICT: return 33;
-      case PROMISED_PROTECTION: return 34;
-      case SIMILAR_GOVERNMENT: return 35;
-      case SAME_GOVERNMENT: return 36;
-      case DIFFERENT_GOVERNMENT: return 37;
-      case SIMILAR_GOVERNMENT_DIFFERENT_GROUP: return 38;
-      default: throw new IllegalArgumentException("No such Diplomacy Bonus"
-          + " Type!");
+    final var values = DiplomacyBonusType.values();
+    for (int i = 0; i < values.length; i++) {
+      if (values[i] == this) {
+        return i;
+      }
     }
+    return -1;
   }
 
   /**
@@ -249,7 +209,6 @@ public enum DiplomacyBonusType {
       case WAR_DECLARTION: return "You have made war declaration";
       case IN_TRADE_ALLIANCE: return "We have trade alliance";
       case IN_ALLIANCE: return "We are at alliance";
-      case DIPLOMAT_CAPTURED: return "Diplomat has been captured";
       case BORDER_CROSSED: return "You have crossed borders";
       case GIVEN_VALUABLE_FREE: return "You have given gift";
       case MADE_DEMAND: return "You have demanded something";
@@ -301,7 +260,6 @@ public enum DiplomacyBonusType {
       case WAR_DECLARTION: return 5;
       case IN_TRADE_ALLIANCE: return 0; // Diplomatic relation
       case IN_ALLIANCE: return 0; // Diplomatic relation
-      case DIPLOMAT_CAPTURED: return 0; // Not used
       case BORDER_CROSSED: return 3;
       case GIVEN_VALUABLE_FREE: return 0;  // Positive bonus
       case MADE_DEMAND: return 7;
@@ -351,7 +309,6 @@ public enum DiplomacyBonusType {
       case WAR_DECLARTION: return "war declarations";
       case IN_TRADE_ALLIANCE: return "in trade alliance"; // Diplomatic relatio
       case IN_ALLIANCE: return "in alliance"; // Diplomatic relation
-      case DIPLOMAT_CAPTURED: return "diplomat captured"; // Not used
       case BORDER_CROSSED: return "borders crossed";
       case GIVEN_VALUABLE_FREE: return "gift";  // Positive bonus
       case MADE_DEMAND: return "demands";
@@ -397,88 +354,11 @@ public enum DiplomacyBonusType {
    * @return Diplomacy Bonus Type
    */
   public static DiplomacyBonusType getTypeByIndex(final int index) {
-    switch (index) {
-    case 0:
-      return DiplomacyBonusType.IN_WAR;
-    case 1:
-      return DiplomacyBonusType.WAR_DECLARTION;
-    case 2:
-      return DiplomacyBonusType.IN_TRADE_ALLIANCE;
-    case 3:
-      return DiplomacyBonusType.IN_ALLIANCE;
-    case 4:
-      return DiplomacyBonusType.DIPLOMAT_CAPTURED;
-    case 5:
-      return DiplomacyBonusType.BORDER_CROSSED;
-    case 6:
-      return DiplomacyBonusType.GIVEN_VALUABLE_FREE;
-    case 7:
-      return DiplomacyBonusType.MADE_DEMAND;
-    case 8:
-      return DiplomacyBonusType.DIPLOMATIC_TRADE;
-    case 9:
-      return DiplomacyBonusType.SAME_RACE;
-    case 10:
-      return DiplomacyBonusType.LONG_PEACE;
-    case 11:
-      return DiplomacyBonusType.INSULT;
-    case 12:
-      return DiplomacyBonusType.NUKED;
-    case 13:
-      return DiplomacyBonusType.NOTHING_TO_TRADE;
-    case 14:
-      return DiplomacyBonusType.IN_DEFENSIVE_PACT;
-    case 15:
-      return DiplomacyBonusType.ESPIONAGE_BORDER_CROSS;
-    case 16:
-      return DiplomacyBonusType.SPY_TRADE;
-    case 17:
-      return DiplomacyBonusType.DIPLOMACY_BONUS;
-    case 18:
-      return DiplomacyBonusType.TRADE_FLEET;
-    case 19:
-      return DiplomacyBonusType.BOARD_PLAYER;
-    case 20:
-      return DiplomacyBonusType.EMBARGO;
-    case 21:
-      return DiplomacyBonusType.LIKED_EMBARGO;
-    case 22:
-      return DiplomacyBonusType.DISLIKED_EMBARGO;
-    case 23:
-      return DiplomacyBonusType.REALM_LOST;
-    case 24:
-      return DiplomacyBonusType.OLYMPICS;
-    case 25:
-      return DiplomacyBonusType.DNS_OLYMPICS;
-    case 26:
-      return DiplomacyBonusType.OLYMPICS_EMBARGO;
-    case 27:
-      return DiplomacyBonusType.PROMISED_VOTE_YES;
-    case 28:
-      return DiplomacyBonusType.PROMISED_VOTE_NO;
-    case 29:
-      return DiplomacyBonusType.PROMISE_KEPT;
-    case 30:
-      return DiplomacyBonusType.PROMISE_BROKEN;
-    case 31:
-      return DiplomacyBonusType.WAR_DECLARATION_AGAINST_US;
-    case 32:
-      return DiplomacyBonusType.FALSE_FLAG;
-    case 33:
-      return DiplomacyBonusType.FREED_CONVICT;
-    case 34:
-      return DiplomacyBonusType.PROMISED_PROTECTION;
-    case 35:
-      return DiplomacyBonusType.SIMILAR_GOVERNMENT;
-    case 36:
-      return DiplomacyBonusType.SAME_GOVERNMENT;
-    case 37:
-      return DiplomacyBonusType.DIFFERENT_GOVERNMENT;
-    case 38:
-      return DiplomacyBonusType.SIMILAR_GOVERNMENT_DIFFERENT_GROUP;
-    default:
+    final var values = DiplomacyBonusType.values();
+    if (index > values.length - 1 || index < 0) {
       throw new IllegalArgumentException("Unexpected diplomacy bonus type!");
     }
+    return values[index];
   }
 
 }

--- a/src/test/java/org/openRealmOfStars/player/diplomacy/DiplomacyBonusListTest.java
+++ b/src/test/java/org/openRealmOfStars/player/diplomacy/DiplomacyBonusListTest.java
@@ -57,7 +57,7 @@ public class DiplomacyBonusListTest {
     assertEquals(-30, list.getDiplomacyBonus());
     result = list.addBonus(DiplomacyBonusType.DIPLOMATIC_TRADE, SpaceRace.HUMAN);
     assertEquals(true, result);
-    assertEquals(-25, list.getDiplomacyBonus());
+    assertEquals(-26, list.getDiplomacyBonus());
     bonus = list.get(1);
     assertEquals(DiplomacyBonusType.DIPLOMATIC_TRADE, bonus.getType());
     result = list.addBonus(DiplomacyBonusType.GIVEN_VALUABLE_FREE, SpaceRace.HUMAN);
@@ -124,7 +124,7 @@ public class DiplomacyBonusListTest {
     assertEquals(true, result);
     assertEquals(3, list.getDiplomacyBonus());
     list.checkPromise(VotingChoice.VOTED_NO, SpaceRace.HUMAN);
-    assertEquals(10, list.getDiplomacyBonus());
+    assertEquals(8, list.getDiplomacyBonus());
   }
 
   @Test
@@ -135,7 +135,7 @@ public class DiplomacyBonusListTest {
     assertEquals(true, result);
     assertEquals(3, list.getDiplomacyBonus());
     list.checkPromise(VotingChoice.VOTED_YES, SpaceRace.HUMAN);
-    assertEquals(-10, list.getDiplomacyBonus());
+    assertEquals(-8, list.getDiplomacyBonus());
   }
 
   @Test
@@ -146,7 +146,7 @@ public class DiplomacyBonusListTest {
     assertEquals(true, result);
     assertEquals(3, list.getDiplomacyBonus());
     list.checkPromise(VotingChoice.VOTED_YES, SpaceRace.HUMAN);
-    assertEquals(10, list.getDiplomacyBonus());
+    assertEquals(8, list.getDiplomacyBonus());
   }
 
   @Test
@@ -157,7 +157,7 @@ public class DiplomacyBonusListTest {
     assertEquals(true, result);
     assertEquals(3, list.getDiplomacyBonus());
     list.checkPromise(VotingChoice.VOTED_NO, SpaceRace.HUMAN);
-    assertEquals(-10, list.getDiplomacyBonus());
+    assertEquals(-8, list.getDiplomacyBonus());
   }
 
   @Test
@@ -180,7 +180,6 @@ public class DiplomacyBonusListTest {
     boolean result = list.addBonus(DiplomacyBonusType.DIPLOMATIC_TRADE, SpaceRace.HUMAN);
     assertEquals(true, result);
     for (int i = 0; i < 110; i++) {
-      assertEquals(5, list.getDiplomacyBonus());
       list.handleForTurn();
     }
     assertEquals(0, list.getDiplomacyBonus());

--- a/src/test/java/org/openRealmOfStars/player/diplomacy/DiplomacyBonusTypeTest.java
+++ b/src/test/java/org/openRealmOfStars/player/diplomacy/DiplomacyBonusTypeTest.java
@@ -40,46 +40,4 @@ public class DiplomacyBonusTypeTest {
   public void testOutOfBound() {
      DiplomacyBonusType.getTypeByIndex(255).getIndex();
   }
-
-  @Test
-  @Category(org.openRealmOfStars.UnitTest.class)
-  public void testCasusBelliScore() {
-    assertEquals(0, DiplomacyBonusType.IN_WAR.getCasusBelliScore());
-    assertEquals(5, DiplomacyBonusType.WAR_DECLARTION.getCasusBelliScore());
-    assertEquals(0, DiplomacyBonusType.IN_TRADE_ALLIANCE.getCasusBelliScore());
-    assertEquals(0, DiplomacyBonusType.IN_ALLIANCE.getCasusBelliScore());
-    assertEquals(0, DiplomacyBonusType.DIPLOMAT_CAPTURED.getCasusBelliScore());
-    assertEquals(3, DiplomacyBonusType.BORDER_CROSSED.getCasusBelliScore());
-    assertEquals(0, DiplomacyBonusType.GIVEN_VALUABLE_FREE.getCasusBelliScore());
-    assertEquals(7, DiplomacyBonusType.MADE_DEMAND.getCasusBelliScore());
-    assertEquals(0, DiplomacyBonusType.DIPLOMATIC_TRADE.getCasusBelliScore());
-    assertEquals(0, DiplomacyBonusType.SAME_RACE.getCasusBelliScore());
-    assertEquals(0, DiplomacyBonusType.LONG_PEACE.getCasusBelliScore());
-    assertEquals(5, DiplomacyBonusType.INSULT.getCasusBelliScore());
-    assertEquals(4, DiplomacyBonusType.NUKED.getCasusBelliScore());
-    assertEquals(0, DiplomacyBonusType.NOTHING_TO_TRADE.getCasusBelliScore());
-    assertEquals(0, DiplomacyBonusType.IN_DEFENSIVE_PACT.getCasusBelliScore());
-    assertEquals(5, DiplomacyBonusType.ESPIONAGE_BORDER_CROSS.getCasusBelliScore());
-    assertEquals(0, DiplomacyBonusType.SPY_TRADE.getCasusBelliScore());
-    assertEquals(0, DiplomacyBonusType.DIPLOMACY_BONUS.getCasusBelliScore());
-    assertEquals(0, DiplomacyBonusType.TRADE_FLEET.getCasusBelliScore());
-    assertEquals(0, DiplomacyBonusType.BOARD_PLAYER.getCasusBelliScore());
-    assertEquals(0, DiplomacyBonusType.EMBARGO.getCasusBelliScore());
-    assertEquals(0, DiplomacyBonusType.LIKED_EMBARGO.getCasusBelliScore());
-    assertEquals(2, DiplomacyBonusType.DISLIKED_EMBARGO.getCasusBelliScore());
-    assertEquals(0, DiplomacyBonusType.REALM_LOST.getCasusBelliScore());
-    assertEquals(0, DiplomacyBonusType.OLYMPICS.getCasusBelliScore());
-    assertEquals(1, DiplomacyBonusType.DNS_OLYMPICS.getCasusBelliScore());
-    assertEquals(0, DiplomacyBonusType.OLYMPICS_EMBARGO.getCasusBelliScore());
-    assertEquals(0, DiplomacyBonusType.PROMISED_VOTE_YES.getCasusBelliScore());
-    assertEquals(0, DiplomacyBonusType.PROMISED_VOTE_NO.getCasusBelliScore());
-    assertEquals(0, DiplomacyBonusType.PROMISE_KEPT.getCasusBelliScore());
-    assertEquals(4, DiplomacyBonusType.PROMISE_BROKEN.getCasusBelliScore());
-    assertEquals(8, DiplomacyBonusType.WAR_DECLARATION_AGAINST_US.getCasusBelliScore());
-    assertEquals(0, DiplomacyBonusType.SIMILAR_GOVERNMENT.getCasusBelliScore());
-    assertEquals(0, DiplomacyBonusType.SIMILAR_GOVERNMENT_DIFFERENT_GROUP.getCasusBelliScore());
-    assertEquals(0, DiplomacyBonusType.SAME_GOVERNMENT.getCasusBelliScore());
-    assertEquals(1, DiplomacyBonusType.DIFFERENT_GOVERNMENT.getCasusBelliScore());
-  }
-
 }

--- a/src/test/java/org/openRealmOfStars/player/diplomacy/DiplomacyTest.java
+++ b/src/test/java/org/openRealmOfStars/player/diplomacy/DiplomacyTest.java
@@ -143,10 +143,6 @@ public class DiplomacyTest {
     assertEquals(GuiStatics.COLOR_DAMAGE_HALF, diplomacy.getLikingAsColor(0));
     diplomacy.getDiplomacyList(0).addBonus(DiplomacyBonusType.WAR_DECLARTION,
         SpaceRace.SPORKS);
-    diplomacy.getDiplomacyList(0).addBonus(DiplomacyBonusType.DIPLOMAT_CAPTURED,
-        SpaceRace.SPORKS);
-    diplomacy.getDiplomacyList(0).addBonus(DiplomacyBonusType.DIPLOMAT_CAPTURED,
-        SpaceRace.SPORKS);
     diplomacy.getDiplomacyList(0).addBonus(DiplomacyBonusType.ESPIONAGE_BORDER_CROSS,
         SpaceRace.SPORKS);
     diplomacy.getDiplomacyList(0).addBonus(DiplomacyBonusType.INSULT,


### PR DESCRIPTION
Also removes unused `DIPLOMAT_CAPTURED` bonus. This change breaks saves.

Some behavioral tests are failing as a consequence, as expected :neutral_face: .