### PR TITLE
Cleanup pom.xml and unused CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: java
-sudo: false
-
-script:
-  - mvn clean verify
-
-after_success:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build Status](https://travis-ci.org/tuomount/Open-Realms-of-Stars.svg?branch=master)](https://travis-ci.org/tuomount/Open-Realms-of-Stars)
-
 # Open Realm of Stars
 
 ![](src/main/resources/resources/images/oros-logo128.png)


### PR DESCRIPTION
Remove now-defunct TravisCI configuration file and badge from `README.md`.

With some more dead configuration cleaned up, @tuomount could you cleanup stale/merged branches from the git repo as well? Some are many years old and likely obsolete and they spam Git interface.