### PR TITLE
Remove more usages of SpaceRace enum

### DIFF
--- a/src/main/java/org/openRealmOfStars/gui/util/GraphRoutines.java
+++ b/src/main/java/org/openRealmOfStars/gui/util/GraphRoutines.java
@@ -164,8 +164,9 @@ public final class GraphRoutines {
     gr2D.dispose();
     return transparentImg;
   }
+
   /**
-   * Draw transparent grey siluete version of bufferedImage.
+   * Draw transparent grey silhouette version of bufferedImage.
    * Image must be 4byte ABGR type.
    * @param image Buffered Image
    * @param transparency Transparency value
@@ -209,12 +210,12 @@ public final class GraphRoutines {
   }
 
   /**
-   * Draw black siluete version of bufferedImage.
+   * Draw black silhouette version of bufferedImage.
    * Image must be 4byte ABGR type.
    * @param image Buffered Image
-   * @return black siluete version of image
+   * @return black silhouette version of image
    */
-  public static BufferedImage blackSiluete(final BufferedImage image) {
+  public static BufferedImage blackSilhouette(final BufferedImage image) {
     if (image == null) {
       return null;
     }

--- a/src/main/java/org/openRealmOfStars/player/leader/Perk.java
+++ b/src/main/java/org/openRealmOfStars/player/leader/Perk.java
@@ -18,6 +18,7 @@ package org.openRealmOfStars.player.leader;
  */
 
 import org.openRealmOfStars.player.race.SpaceRace;
+import org.openRealmOfStars.player.race.trait.TraitIds;
 
 /**
 *
@@ -365,39 +366,11 @@ public enum Perk {
       result = false;
     }
     if (this == Perk.HEALTHY && race.isRoboticRace()) {
-      // Robotic races are robots, and are not healthy
+      // Robotic races cannot be healthy
       result = false;
     }
-    if (this == Perk.HEALTHY && race == SpaceRace.REBORGIANS) {
-      // Reborgians are cyborg, and are not healthy
-      result = false;
-    }
-    if (this == Perk.MAD && race.isRoboticRace()) {
-      // Robitic races are robots, they have no mental problems
-      result = false;
-    }
-    if (this == Perk.PEACEFUL && race == SpaceRace.SPORKS) {
-      // Sporks are not peaceful
-      result = false;
-    }
-    if (this == Perk.PEACEFUL && race == SpaceRace.TEUTHIDAES) {
-      // Teuthidaes are not peaceful
-      result = false;
-    }
-    if (this == Perk.PEACEFUL && race == SpaceRace.REBORGIANS) {
-      // Reborgians are not peaceful
-      result = false;
-    }
-    if (this == Perk.PACIFIST && race == SpaceRace.REBORGIANS) {
-      // Reborgians are not pacifist
-      result = false;
-    }
-    if (this == Perk.CHARISMATIC && race == SpaceRace.MECHIONS) {
-      // Mechions cannot be charismatic
-      result = false;
-    }
-    if (this == Perk.CHARISMATIC && race == SpaceRace.REBORGIANS) {
-      // Reborgians cannot be charismatic
+    if (this == Perk.CHARISMATIC && race.hasTrait(TraitIds.DISGUSTING)) {
+      // Disgusting races cannot be charismatic
       result = false;
     }
     if (this == Perk.SKILLFUL && race.isRoboticRace()) {

--- a/src/main/java/org/openRealmOfStars/player/race/SpaceRaceUtility.java
+++ b/src/main/java/org/openRealmOfStars/player/race/SpaceRaceUtility.java
@@ -88,50 +88,11 @@ public final class SpaceRaceUtility {
     if (name == null) {
       return null;
     }
-    if (name.equals(SpaceRace.HUMAN.getNameSingle())) {
-      return SpaceRace.HUMAN;
-    }
-    if (name.equals(SpaceRace.MECHIONS.getNameSingle())) {
-      return SpaceRace.MECHIONS;
-    }
-    if (name.equals(SpaceRace.SPORKS.getNameSingle())) {
-      return SpaceRace.SPORKS;
-    }
-    if (name.equals(SpaceRace.GREYANS.getNameSingle())) {
-      return SpaceRace.GREYANS;
-    }
-    if (name.equals(SpaceRace.CENTAURS.getNameSingle())) {
-      return SpaceRace.CENTAURS;
-    }
-    if (name.equals(SpaceRace.MOTHOIDS.getNameSingle())) {
-      return SpaceRace.MOTHOIDS;
-    }
-    if (name.equals(SpaceRace.TEUTHIDAES.getNameSingle())) {
-      return SpaceRace.TEUTHIDAES;
-    }
-    if (name.equals(SpaceRace.SCAURIANS.getNameSingle())) {
-      return SpaceRace.SCAURIANS;
-    }
-    if (name.equals(SpaceRace.HOMARIANS.getNameSingle())) {
-      return SpaceRace.HOMARIANS;
-    }
-    if (name.equals(SpaceRace.CHIRALOIDS.getNameSingle())) {
-      return SpaceRace.CHIRALOIDS;
-    }
-    if (name.equals(SpaceRace.REBORGIANS.getNameSingle())) {
-      return SpaceRace.REBORGIANS;
-    }
-    if (name.equals(SpaceRace.LITHORIANS.getNameSingle())) {
-      return SpaceRace.LITHORIANS;
-    }
-    if (name.equals(SpaceRace.ALTEIRIANS.getNameSingle())) {
-      return SpaceRace.ALTEIRIANS;
-    }
-    if (name.equals(SpaceRace.SMAUGIRIANS.getNameSingle())) {
-      return SpaceRace.SMAUGIRIANS;
-    }
-    if (name.equals(SpaceRace.SYNTHDROIDS.getNameSingle())) {
-      return SpaceRace.SYNTHDROIDS;
+
+    for (var race : SpaceRace.values()) {
+      if (name.equals(race.getNameSingle())) {
+        return race;
+      }
     }
     return null;
   }

--- a/src/main/java/org/openRealmOfStars/player/ship/generator/ShipGenerator.java
+++ b/src/main/java/org/openRealmOfStars/player/ship/generator/ShipGenerator.java
@@ -886,20 +886,15 @@ public final class ShipGenerator {
       if (armor != null) {
         armorComp = ShipComponentFactory.createByName(armor.getComponent());
       }
-      if (player.getRace() == SpaceRace.CENTAURS
-          || player.getRace() == SpaceRace.MOTHOIDS) {
-        // Centaurs could ignore defense since they got more hull points.
-        // Mothoids does not have defense tech at start so adding another
-        // weapon.
-        result.addComponent(weapon);
-      } else {
-        if (shieldComp != null
-            && result.getFreeEnergy() >= shieldComp.getEnergyRequirement()) {
-          result.addComponent(shieldComp);
-        } else if (armorComp != null) {
-          result.addComponent(armorComp);
-        }
+
+      // TODO: Consider stronger hulls from MASSIVE_SIZE RaceTrait?
+      if (shieldComp != null
+          && result.getFreeEnergy() >= shieldComp.getEnergyRequirement()) {
+        result.addComponent(shieldComp);
+      } else if (armorComp != null) {
+        result.addComponent(armorComp);
       }
+
       if (result.getNumberOfComponents() == 2) {
         if (shieldComp != null) {
           result.addComponent(shieldComp);
@@ -990,15 +985,12 @@ public final class ShipGenerator {
         cloakComp = ShipComponentFactory.createByName(cloak.getComponent());
       }
       if (probe) {
-        if (player.getRace() == SpaceRace.TEUTHIDAES && scannerComp != null) {
+        // TODO: Consider innate cloaking from STEALTHY RaceTrait?
+        if (cloakComp != null
+            && result.getFreeEnergy() >= cloakComp.getEnergyRequirement()) {
+          result.addComponent(cloakComp);
+        } else if (scannerComp != null) {
           result.addComponent(scannerComp);
-        } else {
-          if (cloakComp != null
-              && result.getFreeEnergy() >= cloakComp.getEnergyRequirement()) {
-            result.addComponent(cloakComp);
-          } else if (scannerComp != null) {
-            result.addComponent(scannerComp);
-          }
         }
       } else {
         if (cloakComp != null

--- a/src/main/java/org/openRealmOfStars/starMap/event/RandomEventUtility.java
+++ b/src/main/java/org/openRealmOfStars/starMap/event/RandomEventUtility.java
@@ -136,7 +136,7 @@ public final class RandomEventUtility {
         if (perks.length > 0) {
           ImageInstruction instructions = new ImageInstruction();
           instructions.addBackground(ImageInstruction.BACKGROUND_GREY_GRADIENT);
-          instructions.addSiluete(info.getRuler().getRace().getNameSingle(),
+          instructions.addSilhouette(info.getRuler().getRace().getNameSingle(),
               ImageInstruction.POSITION_CENTER);
           event.setImageInstructions(instructions.build());
           Perk perk = DiceGenerator.pickRandom(perks);
@@ -192,7 +192,7 @@ public final class RandomEventUtility {
               event.getText(), Icons.getIconByName(Icons.ICON_LEADERS));
           info.getMsgList().addFirstMessage(message);
           instructions.addBackground(ImageInstruction.BACKGROUND_NEBULAE);
-          instructions.addSiluete(leader.getRace().getNameSingle(),
+          instructions.addSilhouette(leader.getRace().getNameSingle(),
               ImageInstruction.POSITION_CENTER);
           event.setImageInstructions(instructions.build());
           message.setRandomEventPop(true);
@@ -222,7 +222,7 @@ public final class RandomEventUtility {
         Perk[] perksGained = LeaderUtility.addRandomPerks(leader);
         ImageInstruction instructions = new ImageInstruction();
         instructions.addBackground(ImageInstruction.BACKGROUND_NEBULAE);
-        instructions.addSiluete(leader.getRace().getNameSingle(),
+        instructions.addSilhouette(leader.getRace().getNameSingle(),
             ImageInstruction.POSITION_CENTER);
         event.setImageInstructions(instructions.build());
         StringBuilder sb = new StringBuilder();
@@ -901,7 +901,7 @@ public final class RandomEventUtility {
       PlayerInfo info = event.getRealm();
       ImageInstruction instructions = new ImageInstruction();
       instructions.addBackground(ImageInstruction.BACKGROUND_GREY_GRADIENT);
-      instructions.addSiluete(info.getRace().getNameSingle(),
+      instructions.addSilhouette(info.getRace().getNameSingle(),
           ImageInstruction.POSITION_LEFT);
       int bestValue = 0;
       Planet mostValuablePlanet = null;
@@ -917,7 +917,7 @@ public final class RandomEventUtility {
       String governorCorrupted = "";
       if (mostValuablePlanet != null
           && mostValuablePlanet.getGovernor() != null) {
-        instructions.addSiluete(mostValuablePlanet.getGovernor().getRace()
+        instructions.addSilhouette(mostValuablePlanet.getGovernor().getRace()
             .getNameSingle(), ImageInstruction.POSITION_RIGHT);
         if (!mostValuablePlanet.getGovernor().hasPerk(Perk.CORRUPTED)) {
           mostValuablePlanet.getGovernor().addPerk(Perk.CORRUPTED);
@@ -928,7 +928,7 @@ public final class RandomEventUtility {
       Leader ruler = info.getRuler();
       String rulerCorrupted = "";
       if (ruler != null) {
-        instructions.addSiluete(ruler.getRace().getNameSingle(),
+        instructions.addSilhouette(ruler.getRace().getNameSingle(),
             ImageInstruction.POSITION_CENTER);
         if (!ruler.hasPerk(Perk.CORRUPTED)) {
           ruler.addPerk(Perk.CORRUPTED);

--- a/src/main/java/org/openRealmOfStars/starMap/newsCorp/ImageInstruction.java
+++ b/src/main/java/org/openRealmOfStars/starMap/newsCorp/ImageInstruction.java
@@ -502,27 +502,27 @@ public class ImageInstruction {
    */
   public static final String ARTIFACT_ON_PLANET = "ArtifactOnPlanet";
 
-  /**
-   * Instruction to draw image
-   */
+  /** Instruction to draw image */
   private static final String IMAGE = "image";
-  /**
-   * Instruction to draw captain image
-   */
+  /** Instruction to draw captain image */
   private static final String CAPTAIN = "captain";
-  /**
-   * Instruction to draw space ship bridge
-   */
+  /** Instruction to draw space ship bridge */
   private static final String BRIDGE = "bridge";
-  /**
-   * Instruction to draw siluete
-   */
-  private static final String SILUETE = "siluete";
+  /** Instruction to draw silhouette */
+  private static final String SILHOUETTE = "silhouette";
 
-  /**
-   * String builder used to collect all the instructions
-   */
+  /** Character for starting parameters */
+  private static final char PARAM_START = '(';
+  /** Character for ending parameters */
+  private static final char PARAM_END = ')';
+  /** Instruction delimiter */
+  private static final char INSTRUCTION_DELIM = '+';
+  /** Parameter delimiter */
+  private static final char PARAMETER_DELIM = ',';
+
+  /** String builder used to collect all the instructions */
   private StringBuilder sb;
+
   /**
    * Constructor for Image instruction
    */
@@ -539,24 +539,6 @@ public class ImageInstruction {
     checkDelim();
     sb.append(instruction);
   }
-  /**
-   * Character for starting parameters
-   */
-  private static final char PARAM_START = '(';
-
-  /**
-   * Character for ending parameters
-   */
-  private static final char PARAM_END = ')';
-
-  /**
-   * Instruction delimiter
-   */
-  private static final char INSTRUCTION_DELIM = '+';
-  /**
-   * Parameter delimiter
-   */
-  private static final char PARAMETER_DELIM = ',';
 
   /**
    * Check if there is instruction delimiter if it is missing
@@ -672,24 +654,8 @@ public class ImageInstruction {
    */
   public ImageInstruction addCaptain(final String image, final int adjust) {
     checkDelim();
-    if (!SpaceRace.CENTAURS.getNameSingle().equals(image)
-        && !SpaceRace.HUMAN.getNameSingle().equals(image)
-        && !SpaceRace.SPORKS.getNameSingle().equals(image)
-        && !SpaceRace.GREYANS.getNameSingle().equals(image)
-        && !SpaceRace.MOTHOIDS.getNameSingle().equals(image)
-        && !SpaceRace.TEUTHIDAES.getNameSingle().equals(image)
-        && !SpaceRace.MECHIONS.getNameSingle().equals(image)
-        && !SpaceRace.SCAURIANS.getNameSingle().equals(image)
-        && !SpaceRace.HOMARIANS.getNameSingle().equals(image)
-        && !SpaceRace.SPACE_PIRATE.getNameSingle().equals(image)
-        && !SpaceRace.CHIRALOIDS.getNameSingle().equals(image)
-        && !SpaceRace.REBORGIANS.getNameSingle().equals(image)
-        && !SpaceRace.LITHORIANS.getNameSingle().equals(image)
-        && !SpaceRace.ALTEIRIANS.getNameSingle().equals(image)
-        && !SpaceRace.SMAUGIRIANS.getNameSingle().equals(image)
-        && !SpaceRace.SYNTHDROIDS.getNameSingle().equals(image)) {
-      throw new IllegalArgumentException("Illegal captain image: "
-          + image);
+    if (SpaceRaceUtility.getRaceByName(image) == null) {
+      throw new IllegalArgumentException("Illegal captain image: " + image);
     }
     sb.append(CAPTAIN);
     sb.append(PARAM_START);
@@ -709,22 +675,7 @@ public class ImageInstruction {
    */
   public ImageInstruction addImage(final String image) {
     checkDelim();
-    if (!SpaceRace.CENTAURS.getNameSingle().equals(image)
-        && !SpaceRace.HUMAN.getNameSingle().equals(image)
-        && !SpaceRace.SPORKS.getNameSingle().equals(image)
-        && !SpaceRace.GREYANS.getNameSingle().equals(image)
-        && !SpaceRace.MOTHOIDS.getNameSingle().equals(image)
-        && !SpaceRace.TEUTHIDAES.getNameSingle().equals(image)
-        && !SpaceRace.MECHIONS.getNameSingle().equals(image)
-        && !SpaceRace.SCAURIANS.getNameSingle().equals(image)
-        && !SpaceRace.HOMARIANS.getNameSingle().equals(image)
-        && !SpaceRace.SPACE_PIRATE.getNameSingle().equals(image)
-        && !SpaceRace.CHIRALOIDS.getNameSingle().equals(image)
-        && !SpaceRace.REBORGIANS.getNameSingle().equals(image)
-        && !SpaceRace.LITHORIANS.getNameSingle().equals(image)
-        && !SpaceRace.ALTEIRIANS.getNameSingle().equals(image)
-        && !SpaceRace.SMAUGIRIANS.getNameSingle().equals(image)
-        && !SpaceRace.SYNTHDROIDS.getNameSingle().equals(image)
+    if (SpaceRaceUtility.getRaceByName(image) == null
         && !LOGO.equals(image)
         && !BIG_BAN.equals(image)
         && !BIG_PEACE.equals(image)
@@ -768,8 +719,7 @@ public class ImageInstruction {
         && !LUSH_VEGETATION.equals(image)
         && !ARTIFACT_ON_PLANET.equals(image)
         && !FACTORY.equals(image)) {
-      throw new IllegalArgumentException("Illegal image: "
-        + image);
+      throw new IllegalArgumentException("Illegal image: " + image);
     }
     sb.append(IMAGE);
     sb.append(PARAM_START);
@@ -787,24 +737,8 @@ public class ImageInstruction {
    */
   public ImageInstruction addBridge(final String image) {
     checkDelim();
-    if (!SpaceRace.CENTAURS.getNameSingle().equals(image)
-        && !SpaceRace.HUMAN.getNameSingle().equals(image)
-        && !SpaceRace.SPORKS.getNameSingle().equals(image)
-        && !SpaceRace.GREYANS.getNameSingle().equals(image)
-        && !SpaceRace.MOTHOIDS.getNameSingle().equals(image)
-        && !SpaceRace.TEUTHIDAES.getNameSingle().equals(image)
-        && !SpaceRace.MECHIONS.getNameSingle().equals(image)
-        && !SpaceRace.SCAURIANS.getNameSingle().equals(image)
-        && !SpaceRace.HOMARIANS.getNameSingle().equals(image)
-        && !SpaceRace.SPACE_PIRATE.getNameSingle().equals(image)
-        && !SpaceRace.CHIRALOIDS.getNameSingle().equals(image)
-        && !SpaceRace.REBORGIANS.getNameSingle().equals(image)
-        && !SpaceRace.LITHORIANS.getNameSingle().equals(image)
-        && !SpaceRace.ALTEIRIANS.getNameSingle().equals(image)
-        && !SpaceRace.SMAUGIRIANS.getNameSingle().equals(image)
-        && !SpaceRace.SYNTHDROIDS.getNameSingle().equals(image)) {
-      throw new IllegalArgumentException("Illegal image: "
-        + image);
+    if (SpaceRaceUtility.getRaceByName(image) == null) {
+      throw new IllegalArgumentException("Illegal image: " + image);
     }
     sb.append(BRIDGE);
     sb.append(PARAM_START);
@@ -814,33 +748,17 @@ public class ImageInstruction {
   }
 
   /**
-   * Add another image siluete to image instructions.
+   * Add another image silhouette to image instructions.
    * @param image image name to place into image
-   * @param position Where siluete is going go be drawn.
+   * @param position Where silhouette is going go be drawn.
    *        POSITION_CENTER, POSITION_LEFT, POSITION_RIGHT
    * @return ImageInstruction with text
    */
-  public ImageInstruction addSiluete(final String image,
+  public ImageInstruction addSilhouette(final String image,
       final String position) {
     checkDelim();
-    if (!SpaceRace.CENTAURS.getNameSingle().equals(image)
-        && !SpaceRace.HUMAN.getNameSingle().equals(image)
-        && !SpaceRace.SPORKS.getNameSingle().equals(image)
-        && !SpaceRace.GREYANS.getNameSingle().equals(image)
-        && !SpaceRace.MOTHOIDS.getNameSingle().equals(image)
-        && !SpaceRace.TEUTHIDAES.getNameSingle().equals(image)
-        && !SpaceRace.MECHIONS.getNameSingle().equals(image)
-        && !SpaceRace.SCAURIANS.getNameSingle().equals(image)
-        && !SpaceRace.HOMARIANS.getNameSingle().equals(image)
-        && !SpaceRace.SPACE_PIRATE.getNameSingle().equals(image)
-        && !SpaceRace.CHIRALOIDS.getNameSingle().equals(image)
-        && !SpaceRace.REBORGIANS.getNameSingle().equals(image)
-        && !SpaceRace.LITHORIANS.getNameSingle().equals(image)
-        && !SpaceRace.ALTEIRIANS.getNameSingle().equals(image)
-        && !SpaceRace.SMAUGIRIANS.getNameSingle().equals(image)
-        && !SpaceRace.SYNTHDROIDS.getNameSingle().equals(image)) {
-      throw new IllegalArgumentException("Illegal image: "
-        + image);
+    if (SpaceRaceUtility.getRaceByName(image) == null) {
+      throw new IllegalArgumentException("Illegal image: " + image);
     }
     if (!POSITION_CENTER.equals(position)
         && !POSITION_LEFT.equals(position)
@@ -848,7 +766,7 @@ public class ImageInstruction {
       throw new IllegalArgumentException("Illegal logo position: "
         + position);
     }
-    sb.append(SILUETE);
+    sb.append(SILHOUETTE);
     sb.append(PARAM_START);
     sb.append(sanitizeParameters(image));
     sb.append(PARAMETER_DELIM);
@@ -914,7 +832,8 @@ public class ImageInstruction {
       throw new IllegalArgumentException("Illegal logo position: "
         + position);
     }
-    if (!PLANET_SPORTS.equals(logoType)
+    if (SpaceRaceUtility.getRaceByName(logoType) == null
+        && !PLANET_SPORTS.equals(logoType)
         && !BIG_BAN.equals(logoType)
         && !BIG_PEACE.equals(logoType)
         && !BIG_NUKE.equals(logoType)
@@ -926,24 +845,7 @@ public class ImageInstruction {
         && !METEOR.equals(logoType)
         && !METEOR_HIT.equals(logoType)
         && !BIG_EXPLOSION.equals(logoType)
-        && !BIG_ORBITAL.equals(logoType)
-        && !SpaceRace.CENTAURS.getNameSingle().equals(logoType)
-        && !SpaceRace.HUMAN.getNameSingle().equals(logoType)
-        && !SpaceRace.SPORKS.getNameSingle().equals(logoType)
-        && !SpaceRace.GREYANS.getNameSingle().equals(logoType)
-        && !SpaceRace.MOTHOIDS.getNameSingle().equals(logoType)
-        && !SpaceRace.TEUTHIDAES.getNameSingle().equals(logoType)
-        && !SpaceRace.MECHIONS.getNameSingle().equals(logoType)
-        && !SpaceRace.SCAURIANS.getNameSingle().equals(logoType)
-        && !SpaceRace.HOMARIANS.getNameSingle().equals(logoType)
-        && !SpaceRace.SPACE_PIRATE.getNameSingle().equals(logoType)
-        && !SpaceRace.CHIRALOIDS.getNameSingle().equals(logoType)
-        && !SpaceRace.REBORGIANS.getNameSingle().equals(logoType)
-        && !SpaceRace.LITHORIANS.getNameSingle().equals(logoType)
-        && !SpaceRace.ALTEIRIANS.getNameSingle().equals(logoType)
-        && !SpaceRace.SMAUGIRIANS.getNameSingle().equals(logoType)
-        && !SpaceRace.SYNTHDROIDS.getNameSingle().equals(logoType)
-        && !SpaceRace.SPACE_MONSTERS.getNameSingle().equals(logoType)) {
+        && !BIG_ORBITAL.equals(logoType)) {
       throw new IllegalArgumentException("Illegal logo type: " + logoType);
     }
     if (!SIZE_FULL.equals(size)
@@ -1276,19 +1178,19 @@ public class ImageInstruction {
   }
 
   /**
-   * Draw siluete on image
+   * Draw silhouette on image
    * @param workImage Image where to draw
-   * @param raceName Race whom's siluete is drawn
+   * @param raceName Race whom's silhouette is drawn
    * @param position LEFT, CENTER or RIGHT
    */
-  private static void paintSiluete(final BufferedImage workImage,
+  private static void paintSilhouette(final BufferedImage workImage,
       final String raceName, final String position) {
     BufferedImage silhoutteImg = GuiStatics.IMAGE_HUMAN_RACE;
     SpaceRace race = SpaceRaceUtility.getRaceByName(raceName);
     if (race != null) {
       silhoutteImg = GuiStatics.getRaceImg(race);
     }
-    silhoutteImg = GraphRoutines.blackSiluete(silhoutteImg);
+    silhoutteImg = GraphRoutines.blackSilhouette(silhoutteImg);
 
     Graphics2D g = (Graphics2D) workImage.getGraphics();
     if (POSITION_CENTER.equals(position)) {
@@ -1594,8 +1496,8 @@ public class ImageInstruction {
       if (BRIDGE.equals(command)) {
         workImage = paintBridge(workImage, parameters[0]);
       }
-      if (SILUETE.equals(command)) {
-        paintSiluete(workImage, parameters[0], parameters[1]);
+      if (SILHOUETTE.equals(command)) {
+        paintSilhouette(workImage, parameters[0], parameters[1]);
       }
       if (RELATION_SYMBOL.equals(command)) {
         Graphics2D g = (Graphics2D) workImage.getGraphics();


### PR DESCRIPTION
Alter `ImageInstruction` to check race names with all defined races.
Allow more Perks based on SpaceRace. Only "game-breaking"  Perks are disabled, and use `RaceTraits` for checking instead `SpaceRace` enum.
Remove some specialized decisions made by ShipGenerator that depended on Race.

The "Smaugirians" `SpaceRace`'s armed-freighters ("smuggling") feature is only case where direct dependency on `SpaceRace` enum was left untouched, as there is no replacement for the feature, yet.