### PR TITLE
Add temporary "Armed freighters" RaceTrait

### DIFF
--- a/src/main/java/org/openRealmOfStars/player/fleet/Fleet.java
+++ b/src/main/java/org/openRealmOfStars/player/fleet/Fleet.java
@@ -33,6 +33,7 @@ import org.openRealmOfStars.player.leader.Job;
 import org.openRealmOfStars.player.leader.Leader;
 import org.openRealmOfStars.player.leader.Perk;
 import org.openRealmOfStars.player.race.SpaceRace;
+import org.openRealmOfStars.player.race.trait.TraitIds;
 import org.openRealmOfStars.player.ship.Ship;
 import org.openRealmOfStars.player.ship.ShipHull;
 import org.openRealmOfStars.player.ship.ShipHullType;
@@ -988,7 +989,7 @@ public class Fleet {
     for (Ship ship : ships) {
       if (!ship.isStarBase() || ship.getFlag(Ship.FLAG_STARBASE_DEPLOYED)) {
         result = result + ship.getTotalMilitaryPower();
-        if (ship.getHull().getRace() == SpaceRace.SMAUGIRIANS
+        if (ship.getHull().getRace().hasTrait(TraitIds.ARMED_FREIGHTERS)
             && ship.getHull().getHullType() == ShipHullType.FREIGHTER) {
           result = result - ship.getTotalMilitaryPower();
         }

--- a/src/main/java/org/openRealmOfStars/player/race/SpaceRace.java
+++ b/src/main/java/org/openRealmOfStars/player/race/SpaceRace.java
@@ -376,6 +376,9 @@ public enum SpaceRace {
     TraitFactory.create(TraitIds.TOLERATE_LAVA).ifPresent(trait -> {
       LITHORIANS.addTrait(trait);
     });
+    TraitFactory.create(TraitIds.ARMED_FREIGHTERS).ifPresent(trait -> {
+      SMAUGIRIANS.addTrait(trait);
+    });
   }
 
   /**

--- a/src/main/java/org/openRealmOfStars/player/race/trait/TraitIds.java
+++ b/src/main/java/org/openRealmOfStars/player/race/trait/TraitIds.java
@@ -145,6 +145,8 @@ public final class TraitIds {
   public static final String TOLERATE_HOT = "TOLERATE_HOT";
   /** Tolerate lava on planets. */
   public static final String TOLERATE_LAVA = "TOLERATE_LAVA";
+  /** Can build freighters with hidden weapons, TODO: Replace, see GH-726 */
+  public static final String ARMED_FREIGHTERS = "ARMED_FREIGHTERS";
 
   /** List storing all hardcoded IDs. Populated at runtime, via reflection. */
   private static List<String> hardcodedIds = null;

--- a/src/main/java/org/openRealmOfStars/player/ship/Ship.java
+++ b/src/main/java/org/openRealmOfStars/player/ship/Ship.java
@@ -1900,7 +1900,7 @@ private int increaseHitChanceByComponent() {
    * @return True if smuggler ship.
    */
   public boolean isSmuggler() {
-    if (getHull().getRace() == SpaceRace.SMAUGIRIANS
+    if (getHull().getRace().hasTrait(TraitIds.ARMED_FREIGHTERS)
         && getHull().getHullType() == ShipHullType.FREIGHTER) {
       return true;
     }

--- a/src/main/java/org/openRealmOfStars/player/ship/ShipHull.java
+++ b/src/main/java/org/openRealmOfStars/player/ship/ShipHull.java
@@ -276,7 +276,7 @@ public class ShipHull {
           "Probe, no weapons allowed. Faster regular and FTL speed.",
           LINE_LENGTH);
     }
-    if (originalBuilder == SpaceRace.SMAUGIRIANS
+    if (originalBuilder.hasTrait(TraitIds.ARMED_FREIGHTERS)
         && getHullType() == ShipHullType.FREIGHTER) {
       hullDescription = IOUtilities.stringWrapper(
           "Freighter, single weapon and privateer module allowed. Cargo ship",

--- a/src/main/java/org/openRealmOfStars/player/ship/generator/ShipGenerator.java
+++ b/src/main/java/org/openRealmOfStars/player/ship/generator/ShipGenerator.java
@@ -1186,7 +1186,7 @@ public final class ShipGenerator {
     ShipComponent power = ShipComponentFactory.createByName(
         player.getTechList().getBestEnergySource().getComponent());
     result.addComponent(power);
-    if (player.getRace() == SpaceRace.SMAUGIRIANS
+    if (player.getRace().hasTrait(TraitIds.ARMED_FREIGHTERS)
         && result.getFreeSlots() > 2) {
       ShipComponent weapon = ShipComponentFactory
           .createByName(player.getTechList().getBestWeapon().getComponent());
@@ -1254,7 +1254,7 @@ public final class ShipGenerator {
         }
       }
     }
-    if (player.getRace() == SpaceRace.SMAUGIRIANS
+    if (player.getRace().hasTrait(TraitIds.ARMED_FREIGHTERS)
         && result.getFreeSlots() > 3
         && (player.getTechList().hasTech("Privateer Mk1")
             || player.getTechList().hasTech("Privateer Mk2")

--- a/src/main/java/org/openRealmOfStars/player/ship/shipdesign/ShipDesign.java
+++ b/src/main/java/org/openRealmOfStars/player/ship/shipdesign/ShipDesign.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 
 import org.openRealmOfStars.player.race.SpaceRace;
 import org.openRealmOfStars.player.race.SpaceRaceUtility;
+import org.openRealmOfStars.player.race.trait.TraitIds;
 import org.openRealmOfStars.player.ship.ShipComponent;
 import org.openRealmOfStars.player.ship.ShipComponentFactory;
 import org.openRealmOfStars.player.ship.ShipComponentType;
@@ -861,7 +862,7 @@ public class ShipDesign {
     if (getFreeSlots() == 0 && hull.getHullType() == ShipHullType.FREIGHTER) {
       flawNoCargoSpace = true;
     }
-    if (hull.getRace() == SpaceRace.SMAUGIRIANS
+    if (hull.getRace().hasTrait(TraitIds.ARMED_FREIGHTERS)
         && hull.getHullType() == ShipHullType.FREIGHTER) {
       if (countWeapons() > 1) {
         designOk = false;
@@ -919,7 +920,7 @@ public class ShipDesign {
       }
       if (comp.getType() == ShipComponentType.PRIVATEERING_MODULE) {
         privateerModule = true;
-        if (hull.getRace() == SpaceRace.SMAUGIRIANS) {
+        if (hull.getRace().hasTrait(TraitIds.ARMED_FREIGHTERS)) {
           if (hull.getHullType() != ShipHullType.PRIVATEER
               && hull.getHullType() != ShipHullType.FREIGHTER) {
             designOk = false;

--- a/src/main/resources/resources/data/traits/base.json
+++ b/src/main/resources/resources/data/traits/base.json
@@ -392,5 +392,11 @@
     "conflictsWith": [
       "TOLERATE_COLD", "TOLERATE_HOT"
     ]
+  },
+  {
+    "id": "ARMED_FREIGHTERS",
+    "name": "Armed freighters",
+    "description": "Can build Freighter Ships with privateering modules and single hidden weapon.",
+    "points": 2
   }
 ]


### PR DESCRIPTION
See #726 .
Temporary solution for keeping Smagurian "armed freighters" mechanic intact, but removing direct dependency on `SpaceRace` enum.