### PR TITLE
Minor styling and Enum indexing cleanup

### DIFF
--- a/src/main/java/org/openRealmOfStars/player/AiDifficulty.java
+++ b/src/main/java/org/openRealmOfStars/player/AiDifficulty.java
@@ -53,18 +53,7 @@ public enum AiDifficulty {
    * @return int
    */
   public int getIndex() {
-    switch (this) {
-      case WEAK: {
-        return 0;
-      }
-      default:
-      case NORMAL: {
-        return 1;
-      }
-      case CHALLENGING: {
-        return 2;
-      }
-    }
+    return this.ordinal();
   }
 
   @Override

--- a/src/main/java/org/openRealmOfStars/player/StartingScenario.java
+++ b/src/main/java/org/openRealmOfStars/player/StartingScenario.java
@@ -84,21 +84,7 @@ public enum StartingScenario {
    * @return int
    */
   public int getIndex() {
-    switch (this) {
-      case RANDOM: return 0;
-      case TEMPERATE_HUMID_SIZE12: return 1;
-      case EARTH: return 2;
-      case TEMPERATE_ARID_SIZE12: return 3;
-      case TEMPERATE_MARINE_SIZE9: return 4;
-      case TEMPERATE_MARINE_SIZE14: return 5;
-      case COLD_HUMID_SIZE12: return 6;
-      case TROPICAL_HUMID_SIZE12: return 7;
-      case HOT_ARID_SIZE12: return 8;
-      case FARMING_PLANET: return 9;
-      case DESTROYED_HOME_PLANET: return 10;
-      case FROM_ANOTHER_GALAXY: return 11;
-      default: throw new IllegalArgumentException("Unknown starting scenario.");
-    }
+    return this.ordinal();
   }
 
   /**
@@ -107,20 +93,10 @@ public enum StartingScenario {
    * @return StartingScenario
    */
   public static StartingScenario getByIndex(final int index) {
-    switch (index) {
-      case 0: return RANDOM;
-      case 1: return TEMPERATE_HUMID_SIZE12;
-      case 2: return EARTH;
-      case 3: return TEMPERATE_ARID_SIZE12;
-      case 4: return TEMPERATE_MARINE_SIZE9;
-      case 5: return TEMPERATE_MARINE_SIZE14;
-      case 6: return COLD_HUMID_SIZE12;
-      case 7: return TROPICAL_HUMID_SIZE12;
-      case 8: return HOT_ARID_SIZE12;
-      case 9: return FARMING_PLANET;
-      case 10: return DESTROYED_HOME_PLANET;
-      case 11: return FROM_ANOTHER_GALAXY;
-      default: throw new IllegalArgumentException("Unknown starting scenario.");
+    if (index >= 0 && index < values().length) {
+      return values()[index];
+    } else {
+      throw new IllegalArgumentException("Unknown starting scenario.");
     }
   }
 

--- a/src/main/java/org/openRealmOfStars/player/race/SpaceRace.java
+++ b/src/main/java/org/openRealmOfStars/player/race/SpaceRace.java
@@ -36,19 +36,13 @@ import org.openRealmOfStars.starMap.planet.enums.TemperatureType;
  */
 public class SpaceRace {
 
-  /**
-   * Space race id
-   */
+  /** Space race id */
   private String id;
 
-  /**
-   * Space race name in plural
-   */
+  /** Space race name in plural */
   private String name;
 
-  /**
-   * Space race name in single
-   */
+  /** Space race name in single */
   private String nameSingle;
 
   /** Attitude for AI */
@@ -89,6 +83,7 @@ public class SpaceRace {
 
   /** Space Race type */
   private SpaceRaceType spaceRaceType;
+
   /**
    * Constructor for SpaceRace.
    * @param id SpaceRace ID
@@ -104,6 +99,7 @@ public class SpaceRace {
     genderList = new ArrayList<>();
     setSpaceRaceType(SpaceRaceType.REGULAR);
   }
+
   /**
    * Space race Id.
    * @return the id
@@ -111,6 +107,7 @@ public class SpaceRace {
   public String getId() {
     return id;
   }
+
   /**
    * Get race name in single format
    * @return Race single name
@@ -135,6 +132,7 @@ public class SpaceRace {
   public void setBridgeId(final String bridgeId) {
     this.bridgeId = bridgeId;
   }
+
   /**
    * Get Space ship id. Currently space ship ID matches space race name.
    * @return Space ship bridge ID.
@@ -150,6 +148,7 @@ public class SpaceRace {
   public void setSpaceShipId(final String spaceShipId) {
     this.spaceShipId = spaceShipId;
   }
+
   /**
    * Add RaceTrait to SpaceRace.
    * Throws IllegalArgumentException if adding trait would result
@@ -212,6 +211,7 @@ public class SpaceRace {
   public void setAttitude(final Attitude attitude) {
     this.attitude = attitude;
   }
+
   /**
    * Get race maximum Radiation
    * @return The race maximum radiation
@@ -689,6 +689,7 @@ public class SpaceRace {
   public void setSpeechSetId(final String speechSetId) {
     this.speechSetId = speechSetId;
   }
+
   /**
    * Get Racial description text. This should contain only physical attributes
    * and description. Nothing about the government or such.
@@ -697,6 +698,7 @@ public class SpaceRace {
   public String getRacialDescription() {
     return description;
   }
+
   /**
    * Set space race description. This is purely for flavor text.
    * @param description Space race description.
@@ -704,6 +706,7 @@ public class SpaceRace {
   public void setDescription(final String description) {
     this.description = description;
   }
+
   /**
    * Get full description about the race, including the stats.
    * @param markDown if true then markDown is being used, otherwise HTML.
@@ -816,6 +819,7 @@ public class SpaceRace {
   public void setRaceBridgeEffect(final BridgeCommandType type) {
     bridgeEffect = type;
   }
+
   /**
    * Get bridge effect for diplomacy screen.
    * @return BridgeCommandType
@@ -839,6 +843,7 @@ public class SpaceRace {
   public void setDiplomacyMusic(final MusicFileInfo diplomacyMusic) {
     this.diplomacyMusic = diplomacyMusic;
   }
+
   /**
    * Get Name Generator type for space race.
    * @return NameGeneratorType Name generator type.
@@ -855,6 +860,7 @@ public class SpaceRace {
       final NameGeneratorType leaderNameGenerator) {
     this.leaderNameGenerator = leaderNameGenerator;
   }
+
   /**
    * Get SpaceRaceType
    * @return the spaceRaceType
@@ -862,6 +868,7 @@ public class SpaceRace {
   public SpaceRaceType getSpaceRaceType() {
     return spaceRaceType;
   }
+
   /**
    * Set SpaceRaceType.
    * @param spaceRaceType the spaceRaceType to set
@@ -877,6 +884,7 @@ public class SpaceRace {
   public boolean isMonster() {
     return this.spaceRaceType == SpaceRaceType.SPACE_MONSTER;
   }
+
   /**
    * Is space race actually space pirate or not?
    * @return True if pirate

--- a/src/main/java/org/openRealmOfStars/player/race/SpaceRaceFactory.java
+++ b/src/main/java/org/openRealmOfStars/player/race/SpaceRaceFactory.java
@@ -75,9 +75,7 @@ public final class SpaceRaceFactory {
     var nonRoboticRaces = Stream.of(getValues())
         .filter(race -> !race.isRoboticRace())
         // Filter out "pseudo-races"
-        .filter(
-            race -> !race.isPirate()
-            && !race.isMonster())
+        .filter(race -> race.getSpaceRaceType() == SpaceRaceType.REGULAR)
         .collect(Collectors.toList());
     if (nonRoboticRaces.isEmpty()) {
       return null;
@@ -92,9 +90,7 @@ public final class SpaceRaceFactory {
   public static SpaceRace getRandomRace() {
     var races = Stream.of(getValues())
         // Filter out "pseudo-races"
-        .filter(
-            race -> !race.isPirate()
-            && !race.isMonster())
+        .filter(race -> race.getSpaceRaceType() == SpaceRaceType.REGULAR)
         .collect(Collectors.toList());
     if (races.isEmpty()) {
       return null;
@@ -225,6 +221,7 @@ class SpaceRaceLoader extends DataLoader<String, SpaceRace> {
       final var name = jobj.getString("Name");
       final var nameSingle = jobj.getString("NameSingle");
       SpaceRace tmp = new SpaceRace(spaceRaceId, name, nameSingle);
+
       final var bridgeId = jobj.getString("BridgeId");
       tmp.setBridgeId(bridgeId);
       final var spaceShipId = jobj.getString("SpaceShipId");

--- a/src/main/java/org/openRealmOfStars/player/race/SpaceRaceUtility.java
+++ b/src/main/java/org/openRealmOfStars/player/race/SpaceRaceUtility.java
@@ -50,23 +50,26 @@ public final class SpaceRaceUtility {
   public static SpaceRace[] getRacesByTrait(final String traitId) {
     return getRacesByTraits(traitId);
   }
+
   /**
    * Get all SpaceRace with certain traits.
    * If any of the traits is found then space race is being selected.
    * @param traitIds Array of Trait Id
    * @return Array of Space Race with certain trait.
    */
-  public static SpaceRace[] getRacesByTraits(final String ... traitIds) {
+  public static SpaceRace[] getRacesByTraits(final String... traitIds) {
     ArrayList<SpaceRace> list = new ArrayList<>();
     for (SpaceRace race : SpaceRaceFactory.getValues()) {
       for (String trait : traitIds) {
         if (race.hasTrait(trait)) {
           list.add(race);
+          break;
         }
       }
     }
     return list.toArray(new SpaceRace[list.size()]);
   }
+
   /**
    * Get Space race by single name
    * @param name Race name in single format

--- a/src/main/java/org/openRealmOfStars/player/ship/ShipComponentType.java
+++ b/src/main/java/org/openRealmOfStars/player/ship/ShipComponentType.java
@@ -194,86 +194,7 @@ public enum ShipComponentType {
    * @return int
    */
   public int getIndex() {
-    switch (this) {
-    case WEAPON_BEAM:
-      return 0;
-    case WEAPON_RAILGUN:
-      return 1;
-    case WEAPON_PHOTON_TORPEDO:
-      return 2;
-    case WEAPON_ECM_TORPEDO:
-      return 3;
-    case WEAPON_HE_MISSILE:
-      return 4;
-    case SCANNER:
-      return 5;
-    case SHIELD:
-      return 6;
-    case ARMOR:
-      return 7;
-    case SHIELD_GENERATOR:
-      return 8;
-    case ENGINE:
-      return 9;
-    case POWERSOURCE:
-      return 10;
-    case CLOAKING_DEVICE:
-      return 11;
-    case JAMMER:
-      return 12;
-    case TARGETING_COMPUTER:
-      return 13;
-    case PLANETARY_INVASION_MODULE:
-      return 14;
-    case COLONY_MODULE:
-      return 15;
-    case PRIVATEERING_MODULE:
-      return 16;
-    case ORBITAL_BOMBS:
-      return 17;
-    case ORBITAL_NUKE:
-      return 18;
-    case STARBASE_COMPONENT:
-      return 19;
-    case ESPIONAGE_MODULE:
-      return 20;
-    case THRUSTERS:
-      return 21;
-    case FIGHTER_BAY:
-      return 22;
-    case PLASMA_BEAM:
-      return 23;
-    case DISTORTION_SHIELD:
-      return 24;
-    case SOLAR_ARMOR:
-      return 25;
-    case ORGANIC_ARMOR:
-      return 26;
-    case TRACTOR_BEAM:
-      return 27;
-    case PLASMA_CANNON:
-      return 28;
-    case ION_CANNON:
-      return 29;
-    case MULTICANNON:
-      return 30;
-    case BITE:
-      return 31;
-    case TENTACLE:
-      return 32;
-    case HEART:
-      return 33;
-    case SPACE_FIN:
-      return 34;
-    case MULTIDIMENSION_SHIELD:
-      return 35;
-    case GRAVITY_RIPPER:
-      return 36;
-    case REPAIR_MODULE:
-      return 37;
-    default:
-      return 0;
-    }
+    return this.ordinal();
   }
 
   /**
@@ -282,85 +203,10 @@ public enum ShipComponentType {
    * @return Ship component type
    */
   public static ShipComponentType getTypeByIndex(final int index) {
-    switch (index) {
-    case 0:
-      return ShipComponentType.WEAPON_BEAM;
-    case 1:
-      return ShipComponentType.WEAPON_RAILGUN;
-    case 2:
-      return ShipComponentType.WEAPON_PHOTON_TORPEDO;
-    case 3:
-      return ShipComponentType.WEAPON_ECM_TORPEDO;
-    case 4:
-      return ShipComponentType.WEAPON_HE_MISSILE;
-    case 5:
-      return ShipComponentType.SCANNER;
-    case 6:
-      return ShipComponentType.SHIELD;
-    case 7:
-      return ShipComponentType.ARMOR;
-    case 8:
-      return ShipComponentType.SHIELD_GENERATOR;
-    case 9:
-      return ShipComponentType.ENGINE;
-    case 10:
-      return ShipComponentType.POWERSOURCE;
-    case 11:
-      return ShipComponentType.CLOAKING_DEVICE;
-    case 12:
-      return ShipComponentType.JAMMER;
-    case 13:
-      return ShipComponentType.TARGETING_COMPUTER;
-    case 14:
-      return ShipComponentType.PLANETARY_INVASION_MODULE;
-    case 15:
-      return ShipComponentType.COLONY_MODULE;
-    case 16:
-      return ShipComponentType.PRIVATEERING_MODULE;
-    case 17:
-      return ShipComponentType.ORBITAL_BOMBS;
-    case 18:
-      return ShipComponentType.ORBITAL_NUKE;
-    case 19:
-      return ShipComponentType.STARBASE_COMPONENT;
-    case 20:
-      return ShipComponentType.ESPIONAGE_MODULE;
-    case 21:
-      return ShipComponentType.THRUSTERS;
-    case 22:
-      return ShipComponentType.FIGHTER_BAY;
-    case 23:
-      return ShipComponentType.PLASMA_BEAM;
-    case 24:
-      return ShipComponentType.DISTORTION_SHIELD;
-    case 25:
-      return ShipComponentType.SOLAR_ARMOR;
-    case 26:
-      return ShipComponentType.ORGANIC_ARMOR;
-    case 27:
-      return ShipComponentType.TRACTOR_BEAM;
-    case 28:
-      return ShipComponentType.PLASMA_CANNON;
-    case 29:
-      return ShipComponentType.ION_CANNON;
-    case 30:
-      return ShipComponentType.MULTICANNON;
-    case 31:
-      return ShipComponentType.BITE;
-    case 32:
-      return ShipComponentType.TENTACLE;
-    case 33:
-      return ShipComponentType.HEART;
-    case 34:
-      return ShipComponentType.SPACE_FIN;
-    case 35:
-      return ShipComponentType.MULTIDIMENSION_SHIELD;
-    case 36:
-      return ShipComponentType.GRAVITY_RIPPER;
-    case 37:
-      return ShipComponentType.REPAIR_MODULE;
-    default:
-      return ShipComponentType.WEAPON_BEAM;
+    if (index >= 0 && index < values().length) {
+      return values()[index];
+    } else {
+      throw new IllegalArgumentException("Unknown Ship Component type");
     }
   }
 

--- a/src/main/java/org/openRealmOfStars/player/ship/ShipHullType.java
+++ b/src/main/java/org/openRealmOfStars/player/ship/ShipHullType.java
@@ -55,22 +55,7 @@ public enum ShipHullType {
    * @return int
    */
   public int getIndex() {
-    switch (this) {
-    case NORMAL:
-      return 0;
-    case FREIGHTER:
-      return 1;
-    case PROBE:
-      return 2;
-    case STARBASE:
-      return 3;
-    case PRIVATEER:
-      return 4;
-    case ORBITAL:
-      return 5;
-    default:
-      throw new IllegalArgumentException("Unexpected ship hull type!");
-    }
+    return this.ordinal();
   }
 
   /**
@@ -79,20 +64,9 @@ public enum ShipHullType {
    * @return Ship hull type
    */
   public static ShipHullType getTypeByIndex(final int index) {
-    switch (index) {
-    case 0:
-      return ShipHullType.NORMAL;
-    case 1:
-      return ShipHullType.FREIGHTER;
-    case 2:
-      return ShipHullType.PROBE;
-    case 3:
-      return ShipHullType.STARBASE;
-    case 4:
-      return ShipHullType.PRIVATEER;
-    case 5:
-      return ShipHullType.ORBITAL;
-    default:
+    if (index >= 0 && index < values().length) {
+      return values()[index];
+    } else {
       throw new IllegalArgumentException("Unexpected ship hull type!");
     }
   }

--- a/src/main/java/org/openRealmOfStars/player/ship/ShipSize.java
+++ b/src/main/java/org/openRealmOfStars/player/ship/ShipSize.java
@@ -43,18 +43,7 @@ public enum ShipSize {
    * @return int
    */
   public int getIndex() {
-    switch (this) {
-    case SMALL:
-      return 0;
-    case MEDIUM:
-      return 1;
-    case LARGE:
-      return 2;
-    case HUGE:
-      return 3;
-    default:
-      return 0;
-    }
+    return this.ordinal();
   }
 
   /**
@@ -87,17 +76,10 @@ public enum ShipSize {
    * @return Ship size
    */
   public static ShipSize getTypeByIndex(final int index) {
-    switch (index) {
-    case 0:
-      return ShipSize.SMALL;
-    case 1:
-      return ShipSize.MEDIUM;
-    case 2:
-      return ShipSize.LARGE;
-    case 3:
-      return ShipSize.HUGE;
-    default:
-      return ShipSize.SMALL;
+    if (index >= 0 && index < values().length) {
+      return values()[index];
+    } else {
+      throw new IllegalArgumentException("Unknown ship size");
     }
   }
 

--- a/src/main/java/org/openRealmOfStars/player/tech/TechType.java
+++ b/src/main/java/org/openRealmOfStars/player/tech/TechType.java
@@ -51,22 +51,7 @@ public enum TechType {
    * @return int
    */
   public int getIndex() {
-    switch (this) {
-    case Combat:
-      return 0;
-    case Defense:
-      return 1;
-    case Hulls:
-      return 2;
-    case Improvements:
-      return 3;
-    case Propulsion:
-      return 4;
-    case Electrics:
-      return 5;
-    default:
-      throw new IllegalArgumentException("Unexpected Tech type!");
-    }
+    return this.ordinal();
   }
 
   /**
@@ -75,21 +60,10 @@ public enum TechType {
    * @return Tech Type
    */
   public static TechType getTypeByIndex(final int index) {
-    switch (index) {
-    case 0:
-      return TechType.Combat;
-    case 1:
-      return TechType.Defense;
-    case 2:
-      return TechType.Hulls;
-    case 3:
-      return TechType.Improvements;
-    case 4:
-      return TechType.Propulsion;
-    case 5:
-      return TechType.Electrics;
-    default:
-      throw new IllegalArgumentException("Unexpected Tech type!");
+    if (index >= 0 && index < values().length) {
+      return values()[index];
+    } else {
+      throw new IllegalArgumentException("Unexpected tech type!");
     }
   }
 

--- a/src/main/java/org/openRealmOfStars/starMap/StarMapGenerator.java
+++ b/src/main/java/org/openRealmOfStars/starMap/StarMapGenerator.java
@@ -1728,30 +1728,34 @@ public class StarMapGenerator {
    */
   private void makeStartingTutorialTexts(final PlayerInfo playerInfo,
       final Planet planet) {
-    if (Game.getTutorial() != null && playerInfo.isHuman()
-        && starMap.isTutorialEnabled()) {
-      String tutorialText = Game.getTutorial().showTutorialText(0);
-      if (tutorialText != null) {
-        Message msg = new Message(MessageType.INFORMATION, tutorialText,
-            Icons.getIconByName(Icons.ICON_TUTORIAL));
-        playerInfo.getMsgList().addNewMessage(msg);
-      }
-      tutorialText = Game.getTutorial().showTutorialText(1);
-      if (tutorialText != null) {
-        Message msg = new Message(MessageType.PLANETARY, tutorialText,
-            Icons.getIconByName(Icons.ICON_TUTORIAL));
-        msg.setCoordinate(planet.getCoordinate());
-        msg.setMatchByString(planet.getName());
-        playerInfo.getMsgList().addNewMessage(msg);
-      }
-      tutorialText = Game.getTutorial().showTutorialText(2);
-      if (tutorialText != null) {
-        Message msg = new Message(MessageType.PLANETARY, tutorialText,
-            Icons.getIconByName(Icons.ICON_TUTORIAL));
-        msg.setCoordinate(planet.getCoordinate());
-        msg.setMatchByString(planet.getName());
-        playerInfo.getMsgList().addNewMessage(msg);
-      }
+    if (Game.getTutorial() == null || !playerInfo.isHuman()
+        || !starMap.isTutorialEnabled()) {
+      return;
+    }
+
+    String tutorialText = Game.getTutorial().showTutorialText(0);
+    if (tutorialText != null) {
+      Message msg = new Message(MessageType.INFORMATION, tutorialText,
+          Icons.getIconByName(Icons.ICON_TUTORIAL));
+      playerInfo.getMsgList().addNewMessage(msg);
+    }
+
+    tutorialText = Game.getTutorial().showTutorialText(1);
+    if (tutorialText != null) {
+      Message msg = new Message(MessageType.PLANETARY, tutorialText,
+          Icons.getIconByName(Icons.ICON_TUTORIAL));
+      msg.setCoordinate(planet.getCoordinate());
+      msg.setMatchByString(planet.getName());
+      playerInfo.getMsgList().addNewMessage(msg);
+    }
+
+    tutorialText = Game.getTutorial().showTutorialText(2);
+    if (tutorialText != null) {
+      Message msg = new Message(MessageType.PLANETARY, tutorialText,
+          Icons.getIconByName(Icons.ICON_TUTORIAL));
+      msg.setCoordinate(planet.getCoordinate());
+      msg.setMatchByString(planet.getName());
+      playerInfo.getMsgList().addNewMessage(msg);
     }
   }
 
@@ -1762,22 +1766,25 @@ public class StarMapGenerator {
    */
   private void makeStartingTutorialTextsInDeepSpace(final PlayerInfo playerInfo,
       final Coordinate coord) {
-    if (Game.getTutorial() != null && playerInfo.isHuman()
-        && starMap.isTutorialEnabled()) {
-      String tutorialText = Game.getTutorial().showTutorialText(0);
-      if (tutorialText != null) {
-        Message msg = new Message(MessageType.INFORMATION, tutorialText,
-            Icons.getIconByName(Icons.ICON_TUTORIAL));
-        playerInfo.getMsgList().addNewMessage(msg);
-      }
-      tutorialText = Game.getTutorial().showTutorialText(3);
-      if (tutorialText != null) {
-        Message msg = new Message(MessageType.FLEET, tutorialText,
-            Icons.getIconByName(Icons.ICON_TUTORIAL));
-        msg.setCoordinate(coord);
-        msg.setMatchByString("Colony #0");
-        playerInfo.getMsgList().addNewMessage(msg);
-      }
+    if (Game.getTutorial() == null || !playerInfo.isHuman()
+        || !starMap.isTutorialEnabled()) {
+      return;
+    }
+
+    String tutorialText = Game.getTutorial().showTutorialText(0);
+    if (tutorialText != null) {
+      Message msg = new Message(MessageType.INFORMATION, tutorialText,
+          Icons.getIconByName(Icons.ICON_TUTORIAL));
+      playerInfo.getMsgList().addNewMessage(msg);
+    }
+
+    tutorialText = Game.getTutorial().showTutorialText(3);
+    if (tutorialText != null) {
+      Message msg = new Message(MessageType.FLEET, tutorialText,
+          Icons.getIconByName(Icons.ICON_TUTORIAL));
+      msg.setCoordinate(coord);
+      msg.setMatchByString("Colony #0");
+      playerInfo.getMsgList().addNewMessage(msg);
     }
   }
 
@@ -1825,6 +1832,7 @@ public class StarMapGenerator {
     }
 
   }
+
   /**
    * Checks if 4x4 area is empty around the coordinate.
    * Note this is not centered. This is more closer

--- a/src/main/java/org/openRealmOfStars/starMap/planet/enums/GravityType.java
+++ b/src/main/java/org/openRealmOfStars/starMap/planet/enums/GravityType.java
@@ -40,12 +40,7 @@ public enum GravityType {
    * @return int
    */
   public int getIndex() {
-    switch (this) {
-      case LOW_GRAVITY: return 1;
-      case NORMAL_GRAVITY: return 2;
-      case HIGH_GRAVITY: return 3;
-      default: throw new IllegalArgumentException("Unknown gravity");
-    }
+    return this.ordinal();
   }
 
   /**
@@ -54,11 +49,10 @@ public enum GravityType {
    * @return GravityType
    */
   public static GravityType getByIndex(final int index) {
-    switch (index) {
-      case 1: return LOW_GRAVITY;
-      case 2: return NORMAL_GRAVITY;
-      case 3: return HIGH_GRAVITY;
-      default: throw new IllegalArgumentException("Unknown gravity");
+    if (index >= 0 && index < values().length) {
+      return values()[index];
+    } else {
+      throw new IllegalArgumentException("Unknown gravity");
     }
   }
 

--- a/src/main/java/org/openRealmOfStars/starMap/planet/enums/PlanetaryEvent.java
+++ b/src/main/java/org/openRealmOfStars/starMap/planet/enums/PlanetaryEvent.java
@@ -99,17 +99,7 @@ public enum PlanetaryEvent {
    * @return Index
    */
   public int getIndex() {
-    switch (this) {
-      case NONE: return 0;
-      case ANCIENT_LAB: return 1;
-      case ANCIENT_FACTORY: return 2;
-      case ANCIENT_TEMPLE: return 3;
-      case ANCIENT_PALACE: return 4;
-      case BLACK_MONOLITH: return 5;
-      case ANCIENT_ARTIFACT: return 6;
-      default:
-        throw new IllegalArgumentException("Unknown planetary event!!");
-    }
+    return this.ordinal();
   }
 
   /**
@@ -154,16 +144,10 @@ public enum PlanetaryEvent {
    * @return PlanetaryEvent
    */
   public static PlanetaryEvent getByIndex(final int index) {
-    switch (index) {
-      case 0: return NONE;
-      case 1: return ANCIENT_LAB;
-      case 2: return ANCIENT_FACTORY;
-      case 3: return ANCIENT_TEMPLE;
-      case 4: return ANCIENT_PALACE;
-      case 5: return BLACK_MONOLITH;
-      case 6: return ANCIENT_ARTIFACT;
-      default:
-        throw new IllegalArgumentException("Unknown planetary event!!");
+    if (index >= 0 && index < values().length) {
+      return values()[index];
+    } else {
+      throw new IllegalArgumentException("Unknown planetary event!!");
     }
   }
 

--- a/src/main/java/org/openRealmOfStars/starMap/planet/enums/RadiationType.java
+++ b/src/main/java/org/openRealmOfStars/starMap/planet/enums/RadiationType.java
@@ -37,13 +37,7 @@ public enum RadiationType {
    * @return int
    */
   public int getIndex() {
-    switch (this) {
-      case NO_RADIATION: return 0;
-      case LOW_RADIATION: return 1;
-      case HIGH_RADIATION: return 2;
-      case VERY_HIGH_RAD: return 3;
-      default: throw new IllegalArgumentException("Unknown radiation type");
-    }
+    return this.ordinal();
   }
 
   /**
@@ -52,12 +46,10 @@ public enum RadiationType {
    * @return RadiationType
    */
   public static RadiationType getByIndex(final int index) {
-    switch (index) {
-      case 0: return NO_RADIATION;
-      case 1: return LOW_RADIATION;
-      case 2: return HIGH_RADIATION;
-      case 3: return VERY_HIGH_RAD;
-      default: throw new IllegalArgumentException("Unknown radiation type");
+    if (index >= 0 && index < values().length) {
+      return values()[index];
+    } else {
+      throw new IllegalArgumentException("Unknown radiation type");
     }
   }
 

--- a/src/main/java/org/openRealmOfStars/starMap/planet/enums/TemperatureType.java
+++ b/src/main/java/org/openRealmOfStars/starMap/planet/enums/TemperatureType.java
@@ -51,17 +51,7 @@ public enum TemperatureType {
    * @return int
    */
   public int getIndex() {
-    switch (this) {
-      case FROZEN: return 0;
-      case ARCTIC: return 1;
-      case COLD: return 2;
-      case TEMPERATE: return 3;
-      case TROPICAL: return 4;
-      case HOT: return 5;
-      case VOLCANIC: return 6;
-      case INFERNO: return 7;
-      default: throw new IllegalArgumentException("Unknown temperature");
-    }
+    return this.ordinal();
   }
 
   /**
@@ -70,16 +60,10 @@ public enum TemperatureType {
    * @return TemperatureType
    */
   public static TemperatureType getByIndex(final int index) {
-    switch (index) {
-      case 0: return FROZEN;
-      case 1: return ARCTIC;
-      case 2: return COLD;
-      case 3: return TEMPERATE;
-      case 4: return TROPICAL;
-      case 5: return HOT;
-      case 6: return VOLCANIC;
-      case 7: return INFERNO;
-      default: throw new IllegalArgumentException("Unknown temperature");
+    if (index >= 0 && index < values().length) {
+      return values()[index];
+    } else {
+      throw new IllegalArgumentException("Unknown temperature");
     }
   }
 

--- a/src/main/java/org/openRealmOfStars/starMap/planet/enums/WaterLevelType.java
+++ b/src/main/java/org/openRealmOfStars/starMap/planet/enums/WaterLevelType.java
@@ -43,15 +43,7 @@ public enum WaterLevelType {
    * @return int
    */
   public int getIndex() {
-    switch (this) {
-      case BARREN: return 0;
-      case DESERT: return 1;
-      case ARID: return 2;
-      case HUMID: return 3;
-      case MARINE: return 4;
-      case OCEAN: return 5;
-      default: throw new IllegalArgumentException("Unknown water level");
-    }
+    return this.ordinal();
   }
 
   /**
@@ -60,14 +52,10 @@ public enum WaterLevelType {
    * @return WaterLevelType
    */
   public static WaterLevelType getByIndex(final int index) {
-    switch (index) {
-      case 0: return BARREN;
-      case 1: return DESERT;
-      case 2: return ARID;
-      case 3: return HUMID;
-      case 4: return MARINE;
-      case 5: return OCEAN;
-      default: throw new IllegalArgumentException("Unknown water level type");
+    if (index >= 0 && index < values().length) {
+      return values()[index];
+    } else {
+      throw new IllegalArgumentException("Unknown water level type");
     }
   }
 


### PR DESCRIPTION
Minor cleanup and styling of mostly recent code and change "getIndex()" and "getByIndex()" of several `enum`s to remove redundant code.

The `enum` indexing for many (not all) `enum` now utilizes Java's built-in methods of `Enum` class, namely `ordinal()` and `values()`, which in many cases greatly reduces boilerplate code. However, declaration order of `enum` values must remain the same in order to keep the same index value.