### PR TITLE
Fix ErrorLoggerTest to work with modern test frameworks

### DIFF
--- a/src/test/java/org/openRealmOfStars/utilities/ErrorLoggerTest.java
+++ b/src/test/java/org/openRealmOfStars/utilities/ErrorLoggerTest.java
@@ -17,11 +17,15 @@ package org.openRealmOfStars.utilities;
  * along with this program; if not, see http://www.gnu.org/licenses/
  */
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mockito.Mockito;
 
+import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test for ErrorLogger
@@ -30,35 +34,43 @@ import java.io.PrintStream;
 
 public class ErrorLoggerTest {
 
+    private PrintStream originalErr;
+    private ByteArrayOutputStream capturedOutput;
+
+    @Before
+    public void setUp() {
+        originalErr = System.err;
+        capturedOutput = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(capturedOutput));
+    }
+
+    @After
+    public void tearDown() {
+        System.setErr(originalErr);
+    }
+
     @Test
     @Category(org.openRealmOfStars.UnitTest.class)
     public void testErrorLoggerShouldWriteToDefaultErrorOutput() {
         String errorMessage = "Error message";
-        PrintStream err =  System.err;
-        System.setErr(Mockito.mock(System.err.getClass()));
-
         ErrorLogger.log(errorMessage);
-
-        Mockito.verify(System.err, Mockito.times(1)).println(errorMessage);
-        System.setErr(err);
+        String output = capturedOutput.toString();
+        assertTrue("Expected error message to be logged", output.contains(errorMessage));
     }
 
     @Test
     @Category(org.openRealmOfStars.UnitTest.class)
     public void testErrorLoggerWhenLogGetException() {
         Exception exception = new Exception("Message");
-        PrintStream err =  System.err;
-        System.setErr(Mockito.mock(System.err.getClass()));
-
         ErrorLogger.log(exception);
+        String output = capturedOutput.toString();
         StackTraceElement stackTraceElement = exception.getStackTrace()[0];
-        Mockito.verify(System.err, Mockito.times(1))
-                .println(stackTraceElement.getClassName()
-                    + " - "
-                    + "Line " + stackTraceElement.getLineNumber()
-                    + " - "
-                    +  exception.getMessage());
-        System.setErr(err);
+        String expectedOutput = stackTraceElement.getClassName()
+                + " - "
+                + "Line " + stackTraceElement.getLineNumber()
+                + " - "
+                + exception.getMessage();
+        assertTrue("Expected exception information to be logged", output.contains(expectedOutput));
     }
 
 }


### PR DESCRIPTION

## Summary

Refactored `ErrorLoggerTest` to capture `System.err` output instead of attempting to mock final classes. This fixes test failures that occur with modern Java/Maven Surefire.

## What Changed

- Replaced Mockito mocking of `System.err` with output capture using `ByteArrayOutputStream`
- Added proper `@Before` and `@After` lifecycle methods to setup/teardown stderr redirection
- Changed assertions from `Mockito.verify()` to standard `assertTrue()` with content checking
- Removed dependency on Mockito for this test (no longer mocks final classes)

## Why This Fix Works

The original test tried to mock `System.err.getClass()`, which returns a final class when running under Maven Surefire in modern Java versions. Mockito 1.10.19 (the project's current version) cannot mock final classes.

This refactored approach:
- ✅ Works with existing Mockito 1.10.19 (no dependency updates needed)
- ✅ Tests actual behavior (correct output logged) not implementation details  
- ✅ More robust - doesn't break if ErrorLogger implementation changes
- ✅ Maintains fast build time (~10 minutes for full test suite)

## Test Results

All 1214 tests pass with 0 failures and 0 errors.

## Test Plan

- [x] Run full test suite - `mvn verify`
- [x] Verify ErrorLoggerTest passes
- [x] Verify all other tests still pass
- [x] No changes to production code, only test improvements

